### PR TITLE
fix styling to avoid ligatures messing with operators, closes issue #68

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -561,6 +561,8 @@ nav {
 .code-text {
   white-space: pre;
   display: block;
+  font-variant-ligatures: none !important;
+  font-feature-settings: "liga" 0, "clig" 0, "calt" 0 !important;
 }
 
 .old-layer {


### PR DESCRIPTION
fixed by adding two lines to CSS styling for code-text
the fix was suggested by Google's AI and tested by me

Fixes #68 