### PR TITLE
Translate content to Brazilian Portuguese

### DIFF
--- a/translations/content/pt-BR/collections/collectors-teeing.yaml
+++ b/translations/content/pt-BR/collections/collectors-teeing.yaml
@@ -1,0 +1,19 @@
+title: Collectors.teeing()
+oldApproach: Duas passagens
+modernApproach: teeing()
+summary: Compute duas agregações em uma única passagem pelo stream.
+explanation: Collectors.teeing() envia cada elemento para dois coletores downstream
+  e combina os resultados. Isso evita percorrer os dados duas vezes ou usar um acumulador
+  mutável.
+whyModernWins:
+- icon: "⚡"
+  title: Passagem única
+  desc: Processe o stream uma vez em vez de duas.
+- icon: "🧩"
+  title: Componível
+  desc: Combine quaisquer dois coletores com uma função de mesclagem.
+- icon: "🔒"
+  title: Resultado imutável
+  desc: Combine diretamente em um record ou objeto de valor.
+support:
+  description: Amplamente disponível desde o JDK 12 (março de 2019)

--- a/translations/content/pt-BR/collections/copying-collections-immutably.yaml
+++ b/translations/content/pt-BR/collections/copying-collections-immutably.yaml
@@ -1,0 +1,19 @@
+title: Cópia imutável de coleções
+oldApproach: Cópia manual + encapsulamento
+modernApproach: List.copyOf()
+summary: Crie uma cópia imutável de qualquer coleção em uma única chamada.
+explanation: List.copyOf(), Set.copyOf() e Map.copyOf() criam snapshots imutáveis
+  de coleções existentes. Se a origem já for uma coleção imutável, nenhuma cópia é
+  feita.
+whyModernWins:
+- icon: "⚡"
+  title: Cópia inteligente
+  desc: Pula a cópia se a origem já for imutável.
+- icon: "📏"
+  title: Uma chamada
+  desc: Sem construção manual de ArrayList + encapsulamento.
+- icon: "🛡️"
+  title: Cópia defensiva
+  desc: Alterações na coleção original não afetam a cópia.
+support:
+  description: Amplamente disponível desde o JDK 10 (março de 2018)

--- a/translations/content/pt-BR/collections/immutable-map-creation.yaml
+++ b/translations/content/pt-BR/collections/immutable-map-creation.yaml
@@ -1,0 +1,18 @@
+title: Criação de mapas imutáveis
+oldApproach: Padrão Builder de Map
+modernApproach: Map.of()
+summary: Crie mapas imutáveis inline sem precisar de um builder.
+explanation: Map.of() aceita pares chave-valor inline e retorna um mapa imutável.
+  Para mais de 10 entradas, use Map.ofEntries() com pares Map.entry().
+whyModernWins:
+- icon: "📏"
+  title: Criação inline
+  desc: Sem necessidade de um mapa mutável temporário.
+- icon: "🔒"
+  title: Resultado imutável
+  desc: O mapa não pode ser modificado após a criação.
+- icon: "🚫"
+  title: Sem chaves/valores nulos
+  desc: Entradas nulas são rejeitadas imediatamente.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/collections/immutable-set-creation.yaml
+++ b/translations/content/pt-BR/collections/immutable-set-creation.yaml
@@ -1,0 +1,18 @@
+title: Criação de conjuntos imutáveis
+oldApproach: Encapsulamento verboso
+modernApproach: Set.of()
+summary: Crie conjuntos imutáveis com uma única chamada de método fábrica.
+explanation: Set.of() cria um conjunto verdadeiramente imutável que rejeita nulos e
+  elementos duplicados no momento da criação. Chega de encapsular conjuntos mutáveis.
+whyModernWins:
+- icon: "📏"
+  title: Conciso
+  desc: Uma linha em vez de três chamadas aninhadas.
+- icon: "🚫"
+  title: Detecta duplicatas
+  desc: Lança exceção se você passar elementos duplicados acidentalmente.
+- icon: "🔒"
+  title: Imutável
+  desc: Nenhuma adição ou remoção é possível após a criação.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/collections/map-entry-factory.yaml
+++ b/translations/content/pt-BR/collections/map-entry-factory.yaml
@@ -1,0 +1,18 @@
+title: Fábrica Map.entry()
+oldApproach: SimpleEntry
+modernApproach: Map.entry()
+summary: Crie entradas de mapa com um método fábrica limpo.
+explanation: Map.entry() substitui o construtor verboso AbstractMap.SimpleEntry. Ele
+  retorna uma entrada imutável, ideal para Map.ofEntries() e operações com streams.
+whyModernWins:
+- icon: "📏"
+  title: Conciso
+  desc: Uma linha em vez de três, com intenção mais clara.
+- icon: "🔒"
+  title: Imutável
+  desc: A entrada retornada não pode ser modificada.
+- icon: "🧩"
+  title: Componível
+  desc: Funciona perfeitamente com Map.ofEntries() para mapas grandes.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/collections/reverse-list-iteration.yaml
+++ b/translations/content/pt-BR/collections/reverse-list-iteration.yaml
@@ -1,0 +1,20 @@
+title: Iteração reversa de listas
+oldApproach: ListIterator manual
+modernApproach: reversed()
+summary: Itere sobre uma lista em ordem reversa com um for-each limpo.
+explanation: O método reversed() de SequencedCollection retorna uma visão em ordem
+  inversa da lista. Essa visão é apoiada pela lista original, então nenhuma cópia é
+  feita. A sintaxe do for aprimorado torna a iteração reversa tão legível quanto a
+  iteração direta.
+whyModernWins:
+- icon: "📖"
+  title: Sintaxe natural
+  desc: For-each aprimorado em vez de ListIterator verboso.
+- icon: "⚡"
+  title: Sem cópia
+  desc: "reversed() retorna uma visão — sem overhead de desempenho."
+- icon: "🧩"
+  title: API consistente
+  desc: Funciona uniformemente em List, Deque e SortedSet.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/collections/sequenced-collections.yaml
+++ b/translations/content/pt-BR/collections/sequenced-collections.yaml
@@ -1,0 +1,20 @@
+title: Coleções sequenciadas
+oldApproach: Aritmética de índice
+modernApproach: getFirst/getLast
+summary: Acesse o primeiro e o último elemento e obtenha visões reversas com métodos
+  de API limpos.
+explanation: SequencedCollection adiciona getFirst(), getLast(), reversed(), addFirst()
+  e addLast() a List, Deque, SortedSet e LinkedHashSet. Chega de aritmética com size()-1
+  ou iteração reversa manual.
+whyModernWins:
+- icon: "📖"
+  title: Autodocumentado
+  desc: getLast() é mais claro que get(size()-1).
+- icon: "🔄"
+  title: Visão reversa
+  desc: "reversed() fornece uma visão — sem necessidade de cópia."
+- icon: "🧩"
+  title: API uniforme
+  desc: Funciona da mesma forma em List, Deque e SortedSet.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/collections/stream-toarray-typed.yaml
+++ b/translations/content/pt-BR/collections/stream-toarray-typed.yaml
@@ -1,0 +1,18 @@
+title: toArray tipado com streams
+oldApproach: Cópia manual de array
+modernApproach: toArray(generator)
+summary: Converta streams em arrays tipados com uma referência de método.
+explanation: "O método toArray(IntFunction) cria um array com tipo correto a partir\
+  \ de um stream. O gerador (String[]::new) indica ao stream qual tipo de array criar."
+whyModernWins:
+- icon: "🎯"
+  title: Tipo seguro
+  desc: "Sem cast de Object[] — o tipo do array está correto."
+- icon: "🔗"
+  title: Encadeável
+  desc: Funciona no final de qualquer pipeline de stream.
+- icon: "📏"
+  title: Conciso
+  desc: Uma expressão substitui o loop manual.
+support:
+  description: Amplamente disponível desde o JDK 8 (março de 2014)

--- a/translations/content/pt-BR/collections/unmodifiable-collectors.yaml
+++ b/translations/content/pt-BR/collections/unmodifiable-collectors.yaml
@@ -1,0 +1,21 @@
+title: Coletores não modificáveis
+oldApproach: collectingAndThen
+modernApproach: stream.toList()
+summary: Colete diretamente para uma lista não modificável com stream.toList().
+explanation: O Java 10 adicionou toUnmodifiableList(), toUnmodifiableSet() e toUnmodifiableMap()
+  para substituir o encapsulamento verboso com collectingAndThen. Para listas especificamente,
+  o stream.toList() do Java 16 oferece uma alternativa ainda mais simples — sem chamada
+  a collect(). Use toUnmodifiableSet() e toUnmodifiableMap() para outros tipos de
+  coleção.
+whyModernWins:
+- icon: "📏"
+  title: O mais curto
+  desc: stream.toList() não precisa de collect() nem de import de Collectors.
+- icon: "🔒"
+  title: Imutável
+  desc: "O resultado não pode ser modificado — sem mutações acidentais."
+- icon: "📖"
+  title: Legível
+  desc: Lê-se naturalmente como o passo final de qualquer pipeline de stream.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/concurrency/completablefuture-chaining.yaml
+++ b/translations/content/pt-BR/concurrency/completablefuture-chaining.yaml
@@ -1,0 +1,19 @@
+title: Encadeamento com CompletableFuture
+oldApproach: Future.get() bloqueante
+modernApproach: CompletableFuture
+summary: Encadeie operações assíncronas sem bloquear, usando CompletableFuture.
+explanation: CompletableFuture permite pipelines assíncronos sem bloqueio. Encadeie
+  operações com thenApply, thenCompose e thenAccept. Trate erros com exceptionally().
+  Combine múltiplos futures com allOf/anyOf.
+whyModernWins:
+- icon: "🔗"
+  title: Encadeável
+  desc: Componha etapas assíncronas em um pipeline legível.
+- icon: "🚫"
+  title: Sem bloqueio
+  desc: Nenhuma thread fica ociosa esperando resultados.
+- icon: "🛡️"
+  title: Tratamento de erros
+  desc: exceptionally() e handle() para recuperação limpa de erros.
+support:
+  description: Amplamente disponível desde o JDK 8 (março de 2014)

--- a/translations/content/pt-BR/concurrency/concurrent-http-virtual.yaml
+++ b/translations/content/pt-BR/concurrency/concurrent-http-virtual.yaml
@@ -1,0 +1,19 @@
+title: HTTP concorrente com virtual threads
+oldApproach: Thread Pool + URLConnection
+modernApproach: Virtual Threads + HttpClient
+summary: Busque muitas URLs simultaneamente com virtual threads e HttpClient.
+explanation: Virtual threads tornam prático criar uma thread por requisição HTTP. Combinadas
+  com HttpClient, substituem padrões complexos de callbacks assíncronos por código
+  bloqueante simples que escala.
+whyModernWins:
+- icon: "♾️"
+  title: Uma thread por requisição
+  desc: Sem dimensionamento de pool — uma virtual thread por URL.
+- icon: "📖"
+  title: Código simples
+  desc: Escreva código bloqueante direto e legível.
+- icon: "⚡"
+  title: Alta vazão
+  desc: Milhares de requisições simultâneas com recursos mínimos.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/concurrency/executor-try-with-resources.yaml
+++ b/translations/content/pt-BR/concurrency/executor-try-with-resources.yaml
@@ -1,0 +1,19 @@
+title: Fechamento automático do ExecutorService
+oldApproach: Encerramento manual
+modernApproach: try-with-resources
+summary: Use try-with-resources para encerramento automático do executor.
+explanation: Desde o Java 19, ExecutorService implementa AutoCloseable. O método close()
+  chama shutdown() e aguarda a conclusão das tarefas. Chega de padrões manuais de
+  try/finally para encerramento.
+whyModernWins:
+- icon: "🧹"
+  title: Limpeza automática
+  desc: O encerramento acontece automaticamente ao sair do bloco.
+- icon: "🛡️"
+  title: Sem vazamentos
+  desc: O executor sempre é encerrado, mesmo se ocorrerem exceções.
+- icon: "📖"
+  title: Padrão familiar
+  desc: Mesmo try-with-resources usado para arquivos, conexões, etc.
+support:
+  description: Amplamente disponível desde o JDK 19 (setembro de 2022)

--- a/translations/content/pt-BR/concurrency/lock-free-lazy-init.yaml
+++ b/translations/content/pt-BR/concurrency/lock-free-lazy-init.yaml
@@ -1,0 +1,19 @@
+title: Inicialização lazy sem locks
+oldApproach: synchronized + volatile
+modernApproach: StableValue
+summary: Substitua double-checked locking por StableValue para singletons lazy.
+explanation: StableValue encapsula o padrão de inicialização lazy com segurança de
+  threads correta. A JVM pode otimizar o caminho de leitura após a inicialização,
+  tornando-o potencialmente mais rápido que leituras volatile.
+whyModernWins:
+- icon: "🧹"
+  title: Sem boilerplate
+  desc: Sem volatile, synchronized ou verificação dupla de null.
+- icon: "⚡"
+  title: Leituras mais rápidas
+  desc: A JVM pode fazer constant-fold após a inicialização.
+- icon: "✅"
+  title: Comprovadamente correto
+  desc: Sem bugs sutis de ordenação — a JVM cuida disso.
+support:
+  description: "Preview no JDK 25 (JEP 502, StableValue). Requer --enable-preview."

--- a/translations/content/pt-BR/concurrency/process-api.yaml
+++ b/translations/content/pt-BR/concurrency/process-api.yaml
@@ -1,0 +1,19 @@
+title: API moderna de processos
+oldApproach: Runtime.exec()
+modernApproach: ProcessHandle
+summary: Inspecione e gerencie processos do sistema operacional com ProcessHandle.
+explanation: ProcessHandle fornece PIDs, informações do processo (comando, argumentos,
+  hora de início, uso de CPU), relacionamentos pai/filho e destruição de processos.
+  Chega de usar internos não documentados de Process.
+whyModernWins:
+- icon: "🔍"
+  title: Informações completas
+  desc: "Acesse PID, comando, argumentos, hora de início e uso de CPU."
+- icon: "🌳"
+  title: Árvore de processos
+  desc: Navegue por pai, filhos e descendentes.
+- icon: "📊"
+  title: Monitoramento
+  desc: onExit() retorna um CompletableFuture para monitoramento assíncrono.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/concurrency/scoped-values.yaml
+++ b/translations/content/pt-BR/concurrency/scoped-values.yaml
@@ -1,0 +1,20 @@
+title: Valores com escopo
+oldApproach: ThreadLocal
+modernApproach: ScopedValue
+summary: Compartilhe dados entre pilhas de chamadas com segurança, sem as armadilhas
+  do ThreadLocal.
+explanation: ScopedValue fornece contexto imutável, herdável e limitado ao escopo.
+  Diferente de ThreadLocal, valores com escopo são automaticamente limpos, funcionam
+  com virtual threads e não podem ser alterados pelos chamados.
+whyModernWins:
+- icon: "🔒"
+  title: Imutável
+  desc: Os chamados podem ler, mas nunca modificar o valor com escopo.
+- icon: "🧹"
+  title: Limpeza automática
+  desc: Sem remove() manual — o valor é limitado ao bloco.
+- icon: "⚡"
+  title: Seguro para virtual threads
+  desc: Funciona eficientemente com milhões de virtual threads.
+support:
+  description: Finalizado no JDK 25 LTS (JEP 506, setembro de 2025).

--- a/translations/content/pt-BR/concurrency/stable-values.yaml
+++ b/translations/content/pt-BR/concurrency/stable-values.yaml
@@ -1,0 +1,19 @@
+title: Valores estáveis
+oldApproach: Double-Checked Locking
+modernApproach: StableValue
+summary: Inicialização lazy thread-safe sem volatile ou synchronized.
+explanation: StableValue fornece um valor inicializado de forma lazy, imutável e com
+  segurança de threads integrada. Sem double-checked locking, sem campos volatile,
+  sem blocos synchronized. A JVM pode até otimizar o caminho de leitura após a inicialização.
+whyModernWins:
+- icon: "🧹"
+  title: Zero boilerplate
+  desc: Sem volatile, synchronized ou verificações de null.
+- icon: "⚡"
+  title: Otimizado pela JVM
+  desc: A JVM pode consolidar o valor após a inicialização.
+- icon: "🛡️"
+  title: Garantia de execução única
+  desc: O supplier executa exatamente uma vez, mesmo sob contenção.
+support:
+  description: "Preview no JDK 25 (JEP 502). Requer --enable-preview."

--- a/translations/content/pt-BR/concurrency/structured-concurrency.yaml
+++ b/translations/content/pt-BR/concurrency/structured-concurrency.yaml
@@ -1,0 +1,21 @@
+title: Concorrência estruturada
+oldApproach: Ciclo de vida manual de threads
+modernApproach: StructuredTaskScope
+summary: Gerencie o ciclo de vida de tarefas concorrentes como uma única unidade de
+  trabalho.
+explanation: A concorrência estruturada trata um grupo de tarefas concorrentes como
+  uma única operação. Se qualquer subtarefa falhar, as demais são canceladas. O escopo
+  garante que não haja vazamento de threads e estabelece relações claras entre pai
+  e filho.
+whyModernWins:
+- icon: "🛡️"
+  title: Sem vazamento de threads
+  desc: Todas as tarefas bifurcadas terminam antes do escopo fechar.
+- icon: "⚡"
+  title: Falha rápida
+  desc: ShutdownOnFailure cancela as demais se uma falhar.
+- icon: "📐"
+  title: Estrutura clara
+  desc: O ciclo de vida da tarefa corresponde ao escopo léxico no código.
+support:
+  description: "Preview no JDK 25 (quinto preview, JEP 505). Requer --enable-preview."

--- a/translations/content/pt-BR/concurrency/thread-sleep-duration.yaml
+++ b/translations/content/pt-BR/concurrency/thread-sleep-duration.yaml
@@ -1,0 +1,19 @@
+title: Thread.sleep com Duration
+oldApproach: Milissegundos
+modernApproach: Duration
+summary: Use Duration para valores de tempo autodocumentados.
+explanation: Thread.sleep(Duration) torna a unidade de tempo explícita. Chega de adivinhar
+  se 5000 significa milissegundos ou microssegundos. Funciona com Duration.ofSeconds,
+  ofMillis, ofMinutes, etc.
+whyModernWins:
+- icon: "📖"
+  title: Autodocumentado
+  desc: Duration.ofSeconds(5) é inequívoco.
+- icon: "🛡️"
+  title: Seguro quanto à unidade
+  desc: Sem risco de passar microssegundos como milissegundos por engano.
+- icon: "🧩"
+  title: Componível
+  desc: "Aritmética com Duration: plus(), multipliedBy(), etc."
+support:
+  description: Amplamente disponível desde o JDK 19 (setembro de 2022)

--- a/translations/content/pt-BR/concurrency/virtual-threads.yaml
+++ b/translations/content/pt-BR/concurrency/virtual-threads.yaml
@@ -1,0 +1,20 @@
+title: Virtual threads
+oldApproach: Platform Threads
+modernApproach: Virtual Threads
+summary: Crie milhões de virtual threads leves em vez de threads pesadas do sistema
+  operacional.
+explanation: Virtual threads são threads leves gerenciadas pela JVM, não pelo sistema
+  operacional. Você pode criar milhões delas sem ajustar pools de threads. São ideais
+  para tarefas com I/O, como chamadas HTTP e consultas a bancos de dados.
+whyModernWins:
+- icon: "⚡"
+  title: Leves
+  desc: Virtual threads usam KB de memória; platform threads usam MB.
+- icon: "♾️"
+  title: Escaláveis
+  desc: Crie milhões de threads — sem necessidade de dimensionar pools.
+- icon: "🧹"
+  title: Modelo simples
+  desc: Escreva código bloqueante que escala como código assíncrono.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/datetime/date-formatting.yaml
+++ b/translations/content/pt-BR/datetime/date-formatting.yaml
@@ -1,0 +1,19 @@
+title: Formatação de datas
+oldApproach: SimpleDateFormat
+modernApproach: DateTimeFormatter
+summary: Formate datas com DateTimeFormatter, imutável e thread-safe.
+explanation: DateTimeFormatter é imutável e thread-safe, ao contrário de SimpleDateFormat.
+  Pode ser armazenado como constante e compartilhado livremente. Formatadores predefinidos
+  como ISO_LOCAL_DATE estão disponíveis para formatos comuns.
+whyModernWins:
+- icon: "🛡️"
+  title: Thread-safe
+  desc: Compartilhe formatadores entre threads sem sincronização.
+- icon: "📋"
+  title: Formatos prontos
+  desc: ISO_LOCAL_DATE, ISO_INSTANT, etc. para formatos padrão.
+- icon: "🔒"
+  title: Imutável
+  desc: Armazene como constantes static final com segurança.
+support:
+  description: Amplamente disponível desde o JDK 8 (março de 2014)

--- a/translations/content/pt-BR/datetime/duration-and-period.yaml
+++ b/translations/content/pt-BR/datetime/duration-and-period.yaml
@@ -1,0 +1,19 @@
+title: Duration e Period
+oldApproach: Cálculo com milissegundos
+modernApproach: Duration / Period
+summary: Calcule diferenças de tempo com Duration e Period, tipos seguros e precisos.
+explanation: Duration é para quantidades baseadas em tempo (horas, minutos, segundos).
+  Period é para quantidades baseadas em datas (anos, meses, dias). ChronoUnit.between()
+  serve para diferenças simples. Todos tratam casos extremos corretamente.
+whyModernWins:
+- icon: "🎯"
+  title: Tipagem segura
+  desc: "Duration para tempo, Period para datas — sem confusão."
+- icon: "🛡️"
+  title: Cálculo correto
+  desc: Lida com horário de verão, anos bissextos e segundos intercalares.
+- icon: "📖"
+  title: Legível
+  desc: ChronoUnit.DAYS.between() se lê de forma natural.
+support:
+  description: Amplamente disponível desde o JDK 8 (março de 2014)

--- a/translations/content/pt-BR/datetime/hex-format.yaml
+++ b/translations/content/pt-BR/datetime/hex-format.yaml
@@ -1,0 +1,19 @@
+title: HexFormat
+oldApproach: Conversão hex manual
+modernApproach: HexFormat
+summary: Converta entre strings hexadecimais e arrays de bytes com HexFormat.
+explanation: HexFormat oferece codificação e decodificação hexadecimal bidirecional
+  para bytes, ints e arrays. Configure delimitadores, prefixo, sufixo e maiúsculas/minúsculas.
+  Sem mais formatação ou parsing manual.
+whyModernWins:
+- icon: "📐"
+  title: Bidirecional
+  desc: "Converta bytes→hex e hex→bytes com uma única API."
+- icon: "🔧"
+  title: Configurável
+  desc: "Delimitadores, prefixo, sufixo, maiúsculas/minúsculas."
+- icon: "📦"
+  title: Suporte a arrays
+  desc: Codifique e decodifique arrays de bytes inteiros de uma vez.
+support:
+  description: Amplamente disponível desde o JDK 17 LTS (setembro de 2021)

--- a/translations/content/pt-BR/datetime/instant-precision.yaml
+++ b/translations/content/pt-BR/datetime/instant-precision.yaml
@@ -1,0 +1,19 @@
+title: Instant com precisão de nanossegundos
+oldApproach: Milissegundos
+modernApproach: Nanossegundos
+summary: Obtenha timestamps com precisão de microssegundos ou nanossegundos.
+explanation: O Java 9 melhorou a resolução do relógio para que Instant.now() capture
+  precisão de microssegundos na maioria das plataformas (nanossegundos em algumas).
+  O antigo currentTimeMillis() fornece apenas milissegundos.
+whyModernWins:
+- icon: "🎯"
+  title: Maior precisão
+  desc: Timestamps em microssegundos/nanossegundos em vez de milissegundos.
+- icon: "📐"
+  title: Tipagem segura
+  desc: "Instant carrega sua precisão — sem longs ambíguos."
+- icon: "🌐"
+  title: Baseado em UTC
+  desc: "Instant é sempre em UTC — sem confusão de fuso horário."
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/datetime/java-time-basics.yaml
+++ b/translations/content/pt-BR/datetime/java-time-basics.yaml
@@ -1,0 +1,19 @@
+title: Fundamentos da API java.time
+oldApproach: Date + Calendar
+modernApproach: java.time.*
+summary: Use tipos de data/hora imutáveis e claros em vez de Date e Calendar.
+explanation: java.time fornece LocalDate, LocalTime, LocalDateTime, Instant, ZonedDateTime
+  — todos imutáveis e thread-safe. Os meses são indexados a partir de 1. Sem mais
+  confusão com Calendar.JANUARY = 0.
+whyModernWins:
+- icon: "🔒"
+  title: Imutável
+  desc: Valores de data/hora não podem ser modificados acidentalmente.
+- icon: "📖"
+  title: API clara
+  desc: "Month.JANUARY, não 0. DayOfWeek.MONDAY, não 2."
+- icon: "🛡️"
+  title: Thread-safe
+  desc: "Sem necessidade de sincronização — compartilhe livremente entre threads."
+support:
+  description: Amplamente disponível desde o JDK 8 (março de 2014)

--- a/translations/content/pt-BR/datetime/math-clamp.yaml
+++ b/translations/content/pt-BR/datetime/math-clamp.yaml
@@ -1,0 +1,19 @@
+title: Math.clamp()
+oldApproach: min/max aninhados
+modernApproach: Math.clamp()
+summary: Limite um valor entre extremos com uma única chamada clara.
+explanation: Math.clamp(value, min, max) restringe um valor ao intervalo [min, max].
+  Mais claro que Math.min/Math.max aninhados e disponível para int, long, float e
+  double.
+whyModernWins:
+- icon: "📖"
+  title: Autodocumentado
+  desc: clamp(value, min, max) é inequívoco.
+- icon: "🛡️"
+  title: Menos propenso a erros
+  desc: Sem mais inversão acidental da ordem de min/max.
+- icon: "🎯"
+  title: Todos os tipos numéricos
+  desc: Funciona com int, long, float e double.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/enterprise/ejb-timer-vs-jakarta-scheduler.yaml
+++ b/translations/content/pt-BR/enterprise/ejb-timer-vs-jakarta-scheduler.yaml
@@ -1,0 +1,24 @@
+title: EJB Timer vs Jakarta Scheduler
+oldApproach: EJB TimerService
+modernApproach: ManagedScheduledExecutorService
+summary: Substitua timers pesados do EJB pelo ManagedScheduledExecutorService do Jakarta
+  Concurrency para agendamentos mais simples.
+explanation: Timers EJB exigem um bean @Stateless ou @Singleton com um callback @Timeout
+  e expressões de agendamento via XML ou anotações. O Jakarta Concurrency oferece o
+  ManagedScheduledExecutorService, que utiliza a conhecida API de agendamento do java.util.concurrent.
+  O resultado é menos boilerplate, testes unitários mais fáceis e nenhuma dependência
+  do container EJB.
+whyModernWins:
+- icon: "🪶"
+  title: Menos boilerplate
+  desc: Sem callback @Timeout ou ScheduleExpression — use a API padrão do ScheduledExecutorService.
+- icon: "🧪"
+  title: Melhor testabilidade
+  desc: Métodos simples e mocks de executor tornam os testes unitários diretos, sem
+    container EJB.
+- icon: "☁️"
+  title: Pronto para a nuvem
+  desc: Executores gerenciados integram-se ao ciclo de vida do container e funcionam
+    em runtimes leves.
+support:
+  description: Disponível desde o Jakarta EE 10 / Concurrency 3.0

--- a/translations/content/pt-BR/enterprise/ejb-vs-cdi.yaml
+++ b/translations/content/pt-BR/enterprise/ejb-vs-cdi.yaml
@@ -1,0 +1,24 @@
+title: EJB versus CDI
+oldApproach: EJB
+modernApproach: CDI Bean
+summary: Substitua EJBs pesados por beans CDI leves para injeção de dependências e
+  transações.
+explanation: CDI (Contexts and Dependency Injection) oferece a mesma injeção de dependências
+  e gerenciamento de transações dos EJBs, mas como classes Java simples sem interfaces
+  ou superclasses específicas do container. Escopos como @ApplicationScoped e @RequestScoped
+  controlam o ciclo de vida, e @Transactional substitui a semântica obrigatória de
+  transações do EJB.
+whyModernWins:
+- icon: "🪶"
+  title: Leve
+  desc: Beans CDI são classes Java simples sem interfaces ou descritores específicos
+    do EJB.
+- icon: "💉"
+  title: Injeção unificada
+  desc: "@Inject funciona para qualquer bean gerenciado, recursos JAX-RS e componentes
+    Jakarta EE."
+- icon: "🧪"
+  title: Testes unitários fáceis
+  desc: Classes simples sem overhead de proxy EJB são fáceis de instanciar e mockar.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/jdbc-resultset-vs-jpa-criteria.yaml
+++ b/translations/content/pt-BR/enterprise/jdbc-resultset-vs-jpa-criteria.yaml
@@ -1,0 +1,26 @@
+title: Mapeamento JDBC ResultSet vs JPA Criteria API
+oldApproach: JDBC ResultSet
+modernApproach: JPA Criteria API
+summary: Substitua o mapeamento manual de JDBC ResultSet pela Criteria API type-safe
+  do JPA para consultas dinâmicas.
+explanation: JDBC puro exige construir strings SQL, definir parâmetros por índice e
+  mapear cada coluna do ResultSet manualmente — um processo propenso a erros que quebra
+  silenciosamente quando colunas mudam. A Criteria API do JPA constrói consultas programaticamente
+  usando um padrão builder type-safe. Nomes de colunas são validados contra o modelo
+  de entidades, o mapeamento de resultados é automático e consultas dinâmicas complexas
+  se compõem de forma limpa, sem concatenação de strings.
+whyModernWins:
+- icon: "🔒"
+  title: Consultas type-safe
+  desc: O builder Criteria detecta incompatibilidades de nome e tipo de campo em tempo
+    de compilação.
+- icon: "🗺️"
+  title: Mapeamento automático
+  desc: O JPA mapeia as linhas do resultado para objetos de entidade — sem extração
+    manual coluna por coluna.
+- icon: "🧩"
+  title: Predicados composíveis
+  desc: Cláusulas where dinâmicas se compõem de forma limpa com and(), or() e objetos
+    Predicate reutilizáveis.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/jdbc-vs-jooq.yaml
+++ b/translations/content/pt-BR/enterprise/jdbc-vs-jooq.yaml
@@ -1,0 +1,28 @@
+title: JDBC versus jOOQ
+oldApproach: JDBC puro
+modernApproach: jOOQ SQL DSL
+summary: Substitua SQL baseado em strings com JDBC puro pela DSL SQL type-safe e fluente
+  do jOOQ.
+explanation: "jOOQ (Java Object Oriented Querying) gera código Java a partir do esquema\
+  \ do banco de dados, transformando nomes de tabelas e colunas em constantes Java\
+  \ type-safe. A DSL fluente espelha a sintaxe SQL, tornando as consultas legíveis\
+  \ e composíveis. Todos os parâmetros são vinculados automaticamente, eliminando o\
+  \ risco de SQL injection. Diferente do JPA/JPQL, o jOOQ abraça o SQL por completo\
+  \ — window functions, CTEs, cláusulas RETURNING e extensões específicas de cada banco\
+  \ são cidadãos de primeira classe."
+whyModernWins:
+- icon: "🔒"
+  title: Colunas type-safe
+  desc: Nomes de colunas são constantes Java geradas — erros de digitação e incompatibilidades
+    de tipo se tornam erros de compilação em vez de falhas em tempo de execução.
+- icon: "📖"
+  title: Fluência SQL
+  desc: A DSL do jOOQ espelha a sintaxe SQL de perto, então JOINs complexos, subqueries
+    e CTEs continuam legíveis.
+- icon: "🛡️"
+  title: Livre de injection por design
+  desc: Parâmetros são sempre vinculados com segurança — sem concatenação de strings
+    significa sem risco de SQL injection.
+support:
+  description: "A edição open-source do jOOQ suporta todos os principais bancos de\
+    \ dados open-source; bancos comerciais mais antigos requerem licença paga"

--- a/translations/content/pt-BR/enterprise/jdbc-vs-jpa.yaml
+++ b/translations/content/pt-BR/enterprise/jdbc-vs-jpa.yaml
@@ -1,0 +1,24 @@
+title: JDBC versus JPA
+oldApproach: JDBC
+modernApproach: JPA EntityManager
+summary: Substitua o boilerplate verboso do JDBC pelo mapeamento objeto-relacional
+  e EntityManager do JPA.
+explanation: "JPA (Jakarta Persistence API) mapeia objetos Java para linhas do banco\
+  \ de dados, eliminando o processamento manual de ResultSet e a concatenação de strings\
+  \ SQL. O EntityManager oferece find(), persist() e consultas JPQL para que você trabalhe\
+  \ com objetos de domínio em vez de SQL puro, enquanto o container gerencia o pool\
+  \ de conexões e as transações."
+whyModernWins:
+- icon: "🗺️"
+  title: Mapeamento de objetos
+  desc: Entidades são classes anotadas simples — sem tradução manual de ResultSet para
+    objetos.
+- icon: "🔒"
+  title: Consultas type-safe
+  desc: JPQL opera sobre tipos e campos de entidades em vez de strings brutas de tabelas
+    e colunas.
+- icon: "⚡"
+  title: Cache integrado
+  desc: Caches de primeiro e segundo nível reduzem round-trips ao banco de dados automaticamente.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/jndi-lookup-vs-cdi-injection.yaml
+++ b/translations/content/pt-BR/enterprise/jndi-lookup-vs-cdi-injection.yaml
@@ -1,0 +1,26 @@
+title: JNDI Lookup vs Injeção CDI
+oldApproach: JNDI Lookup
+modernApproach: CDI @Inject
+summary: Substitua lookups JNDI frágeis baseados em strings por injeção CDI type-safe
+  para recursos gerenciados pelo container.
+explanation: O padrão tradicional JNDI obriga o uso de nomes de recursos baseados em
+  strings, tratamento de NamingException e gerenciamento de um InitialContext. A injeção
+  CDI com @Inject (ou @Resource para recursos do container) permite que o container
+  conecte as dependências automaticamente. Erros de digitação se tornam erros em tempo
+  de compilação, e as classes ficam mais fáceis de testar porque as dependências podem
+  ser injetadas diretamente.
+whyModernWins:
+- icon: "🔒"
+  title: Conexão type-safe
+  desc: Erros de injeção são detectados no deploy, não em tempo de execução via lookups
+    de strings.
+- icon: "🗑️"
+  title: Sem boilerplate
+  desc: Elimina a criação de InitialContext, strings de nomes JNDI e tratamento de
+    NamingException.
+- icon: "🧪"
+  title: Testável
+  desc: Dependências são campos injetados, facilmente substituíveis por mocks em testes
+    unitários.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/jpa-vs-jakarta-data.yaml
+++ b/translations/content/pt-BR/enterprise/jpa-vs-jakarta-data.yaml
@@ -1,0 +1,25 @@
+title: JPA versus Jakarta Data
+oldApproach: JPA EntityManager
+modernApproach: Jakarta Data Repository
+summary: Declare uma interface de repositório e deixe o Jakarta Data gerar a implementação
+  do DAO automaticamente.
+explanation: O Jakarta Data (Jakarta EE 11) transforma o acesso a dados em uma pura
+  declaração de interface. Você anota uma interface com @Repository e estende um tipo
+  de repositório embutido como CrudRepository. O runtime gera a implementação — incluindo
+  consultas derivadas a partir de nomes de métodos como findByName — eliminando boilerplate
+  do EntityManager, strings JPQL e métodos save/find escritos manualmente.
+whyModernWins:
+- icon: "🪄"
+  title: Zero boilerplate
+  desc: Declare a interface; o container gera a implementação completa do DAO no momento
+    do deploy.
+- icon: "🔍"
+  title: Consultas derivadas
+  desc: Nomes de métodos como findByNameAndStatus são interpretados automaticamente
+    — sem necessidade de JPQL ou SQL.
+- icon: "🔌"
+  title: Portável
+  desc: Qualquer runtime compatível com Jakarta EE 11 fornece a implementação do repositório
+    sem lock-in de fornecedor.
+support:
+  description: Disponível desde o Jakarta EE 11 / Java 21 (2024)

--- a/translations/content/pt-BR/enterprise/jsf-managed-bean-vs-cdi-named.yaml
+++ b/translations/content/pt-BR/enterprise/jsf-managed-bean-vs-cdi-named.yaml
@@ -1,0 +1,24 @@
+title: JSF Managed Bean vs CDI Named Bean
+oldApproach: "@ManagedBean"
+modernApproach: "@Named + CDI"
+summary: Substitua o @ManagedBean depreciado do JSF por CDI @Named para um modelo
+  unificado de injeção de dependências.
+explanation: O @ManagedBean e @ManagedProperty do JSF foram depreciados no Jakarta
+  Faces 2.3 e removidos no Jakarta EE 10. A substituição baseada em CDI usa @Named
+  para expor o bean a expressões EL e @Inject para a conexão de dependências. Isso
+  unifica o modelo de beans — páginas JSF, recursos JAX-RS e EJBs compartilham o mesmo
+  container CDI.
+whyModernWins:
+- icon: "🔗"
+  title: Modelo unificado
+  desc: Um único container CDI gerencia todos os beans — JSF, REST e camadas de serviço
+    compartilham a mesma injeção.
+- icon: "🗑️"
+  title: Menos boilerplate
+  desc: "@Inject substitui @ManagedProperty e seu método setter obrigatório."
+- icon: "🔮"
+  title: "À prova de futuro"
+  desc: "@ManagedBean foi removido no Jakarta EE 10; @Named é a substituição suportada."
+support:
+  description: "CDI @Named disponível desde o Java EE 6; @ManagedBean removido no Jakarta
+    EE 10"

--- a/translations/content/pt-BR/enterprise/manual-transaction-vs-declarative.yaml
+++ b/translations/content/pt-BR/enterprise/manual-transaction-vs-declarative.yaml
@@ -1,0 +1,24 @@
+title: Transação JPA Manual vs @Transactional Declarativo
+oldApproach: Transação manual
+modernApproach: "@Transactional"
+summary: Substitua blocos verbosos de begin/commit/rollback por uma única anotação
+  @Transactional.
+explanation: O gerenciamento manual de transações exige chamadas explícitas a begin(),
+  commit() e rollback() envolvidas em blocos try-catch — cada método de serviço repete
+  esse boilerplate. A anotação @Transactional delega o gerenciamento do ciclo de vida
+  ao container, que inicia uma transação antes do método, faz commit em caso de sucesso
+  e rollback automático em caso de RuntimeException.
+whyModernWins:
+- icon: "🗑️"
+  title: Sem boilerplate
+  desc: Uma anotação substitui blocos repetitivos de try-catch com begin/commit/rollback.
+- icon: "🛡️"
+  title: Rollback mais seguro
+  desc: O container garante rollback em exceções não verificadas — sem risco de esquecer
+    o bloco catch.
+- icon: "📐"
+  title: Controle declarativo
+  desc: Propagação, isolamento e regras de rollback são expressos como atributos da
+    anotação.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/mdb-vs-reactive-messaging.yaml
+++ b/translations/content/pt-BR/enterprise/mdb-vs-reactive-messaging.yaml
@@ -1,0 +1,25 @@
+title: Message-Driven Bean vs Reactive Messaging
+oldApproach: Message-Driven Bean
+modernApproach: Reactive Messaging
+summary: Substitua Message-Driven Beans JMS por MicroProfile Reactive Messaging para
+  processamento de eventos mais simples.
+explanation: Message-Driven Beans exigem implementar MessageListener, configurar propriedades
+  de ativação e desserializar mensagens JMS manualmente. O MicroProfile Reactive Messaging
+  usa uma simples anotação @Incoming em um método que recebe objetos tipados diretamente.
+  A configuração do canal é externalizada, tornando o código agnóstico ao broker e
+  muito mais fácil de testar.
+whyModernWins:
+- icon: "🪶"
+  title: Código mínimo
+  desc: Um único método @Incoming substitui a classe MDB, a interface MessageListener
+    e a configuração de ativação.
+- icon: "🔌"
+  title: Agnóstico ao broker
+  desc: Troque conectores Kafka, AMQP ou JMS via configuração sem alterar o código
+    da aplicação.
+- icon: "☁️"
+  title: Ideal para a nuvem
+  desc: Backpressure de reactive streams e runtime leve tornam-no ideal para deploys
+    em containers.
+support:
+  description: Disponível desde o MicroProfile 4.0 / SmallRye Reactive Messaging

--- a/translations/content/pt-BR/enterprise/servlet-vs-jaxrs.yaml
+++ b/translations/content/pt-BR/enterprise/servlet-vs-jaxrs.yaml
@@ -1,0 +1,24 @@
+title: Servlet versus JAX-RS
+oldApproach: HttpServlet
+modernApproach: JAX-RS Resource
+summary: Substitua o boilerplate verboso de HttpServlet por classes de recurso JAX-RS
+  declarativas.
+explanation: JAX-RS (Jakarta RESTful Web Services) permite expor endpoints REST usando
+  anotações simples como @GET, @Path e @Produces. Sem mais parsing manual de parâmetros
+  de requisição ou definição de content types na resposta — o runtime cuida do marshalling
+  e do roteamento automaticamente.
+whyModernWins:
+- icon: "📐"
+  title: Roteamento declarativo
+  desc: Anotações definem método HTTP, caminho e content type em vez de dispatch imperativo
+    com if/else.
+- icon: "🔄"
+  title: Marshalling automático
+  desc: Retorne POJOs diretamente; o runtime os serializa para JSON ou XML com base
+    em @Produces.
+- icon: "🧪"
+  title: Testes mais fáceis
+  desc: Classes de recurso são objetos Java simples, testáveis sem um container de
+    servlets.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/singleton-ejb-vs-cdi-application-scoped.yaml
+++ b/translations/content/pt-BR/enterprise/singleton-ejb-vs-cdi-application-scoped.yaml
@@ -1,0 +1,25 @@
+title: Singleton EJB vs CDI @ApplicationScoped
+oldApproach: "@Singleton EJB"
+modernApproach: "@ApplicationScoped CDI"
+summary: Substitua Singleton EJBs por beans CDI @ApplicationScoped para um gerenciamento
+  de estado compartilhado mais simples.
+explanation: Singleton EJBs agrupam gerenciamento de concorrência (@Lock, @ConcurrencyManagement)
+  e inicialização antecipada (@Startup) no container EJB. Um bean CDI @ApplicationScoped
+  alcança o mesmo ciclo de vida de instância única com muito menos cerimônia. Quando
+  controle de concorrência é necessário, utilitários padrão do java.util.concurrent
+  oferecem controle mais granular do que as anotações de lock do EJB.
+whyModernWins:
+- icon: "🪶"
+  title: Menos ruído de anotações
+  desc: Sem @ConcurrencyManagement, @Lock ou @Startup — apenas uma única anotação
+    @ApplicationScoped.
+- icon: "🔧"
+  title: Concorrência flexível
+  desc: Use locks do java.util.concurrent ou volatile para exatamente a thread-safety
+    que você precisa.
+- icon: "🧪"
+  title: Testes fáceis
+  desc: Beans CDI simples podem ser instanciados diretamente em testes sem um container
+    EJB.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/soap-vs-jakarta-rest.yaml
+++ b/translations/content/pt-BR/enterprise/soap-vs-jakarta-rest.yaml
@@ -1,0 +1,23 @@
+title: SOAP Web Services vs Jakarta REST
+oldApproach: JAX-WS / SOAP
+modernApproach: Jakarta REST / JSON
+summary: Substitua endpoints pesados SOAP/WSDL por recursos Jakarta REST limpos retornando
+  JSON.
+explanation: Web services baseados em SOAP dependem de contratos WSDL, marshalling
+  XML e anotações JAX-WS que adicionam overhead significativo. Jakarta REST (anteriormente
+  JAX-RS) usa anotações intuitivas como @GET, @Path e @Produces para expor APIs RESTful
+  JSON. O modelo de programação é mais simples, os payloads são menores e a abordagem
+  está alinhada com a comunicação moderna entre microsserviços.
+whyModernWins:
+- icon: "🪶"
+  title: Payloads mais leves
+  desc: JSON é mais compacto que envelopes SOAP XML, reduzindo banda e overhead de
+    parsing.
+- icon: "📐"
+  title: Anotações simples
+  desc: "@GET, @Path e @Produces substituem a cerimônia de WSDL, @WebService e @WebMethod."
+- icon: "🔌"
+  title: Pronto para microsserviços
+  desc: REST/JSON é o padrão para comunicação entre serviços em arquiteturas cloud-native.
+support:
+  description: Amplamente disponível desde o Jakarta EE 8 / Java 11

--- a/translations/content/pt-BR/enterprise/spring-api-versioning.yaml
+++ b/translations/content/pt-BR/enterprise/spring-api-versioning.yaml
@@ -1,0 +1,28 @@
+title: Versionamento de API no Spring Framework 7
+oldApproach: Versionamento manual via caminho de URL
+modernApproach: Versionamento nativo de API
+summary: Substitua controllers duplicados com prefixo de versão pelo suporte nativo
+  de versionamento de API do Spring Framework 7.
+explanation: Antes do Spring Framework 7, o versionamento de API exigia classes de
+  controller separadas por versão (ex. /api/v1/products, /api/v2/products), duplicando
+  mapeamentos de requisição e espalhando a lógica de versão por muitos arquivos. O
+  Spring Framework 7 introduz versionamento nativo através de um novo atributo version
+  em @RequestMapping e anotações relacionadas, além de um hook configureApiVersioning
+  no WebMvcConfigurer. A versão pode ser resolvida a partir de um header de requisição,
+  um segmento de caminho URL ou um parâmetro de query — tudo controlado em um único
+  lugar.
+whyModernWins:
+- icon: "🗂️"
+  title: Sem duplicação de controllers
+  desc: Todas as versões ficam em uma única classe de controller; apenas os métodos
+    handler individuais carregam o atributo version.
+- icon: "⚙️"
+  title: Estratégia de versão centralizada
+  desc: Alterne entre versionamento por header, URL ou query-param em uma única chamada
+    configureApiVersioning.
+- icon: "📈"
+  title: Evolução incremental
+  desc: Adicione uma nova versão a um método sem alterar endpoints não relacionados
+    ou criar novos arquivos de controller.
+support:
+  description: Disponível desde o Spring Framework 7.0 (requer Java 17+)

--- a/translations/content/pt-BR/enterprise/spring-null-safety-jspecify.yaml
+++ b/translations/content/pt-BR/enterprise/spring-null-safety-jspecify.yaml
@@ -1,0 +1,29 @@
+title: Null Safety no Spring com JSpecify
+oldApproach: Spring @NonNull/@Nullable
+modernApproach: JSpecify @NullMarked
+summary: O Spring 7 adota as anotações JSpecify, tornando non-null o padrão e reduzindo
+  o ruído de anotações.
+explanation: O Spring 5 e 6 introduziram suas próprias anotações de null safety no
+  pacote org.springframework.lang. Embora úteis, eram específicas do framework e exigiam
+  anotar cada elemento non-null explicitamente. O Spring 7 migra para o JSpecify, um
+  padrão cross-ecosystem para null safety. A anotação @NullMarked no nível de classe
+  ou pacote declara que todos os tipos não anotados são non-null por padrão. Apenas
+  tipos realmente nullable precisam da anotação @Nullable, reduzindo drasticamente
+  a verbosidade. As anotações JSpecify são reconhecidas por ferramentas de análise
+  estática como NullAway, Error Prone e IntelliJ IDEA, trazendo suporte de ferramentas
+  mais rico do que as anotações específicas do Spring ofereciam.
+whyModernWins:
+- icon: "✂️"
+  title: Non-null por padrão
+  desc: "@NullMarked torna todos os tipos não anotados non-null, então apenas exceções
+    nullable precisam de anotação."
+- icon: "🌐"
+  title: Padrão do ecossistema
+  desc: Anotações JSpecify são um padrão cross-framework reconhecido por NullAway,
+    Error Prone e IDEs.
+- icon: "🔍"
+  title: Ferramentas mais ricas
+  desc: Analisadores estáticos modernos entendem o modelo de null do JSpecify e reportam
+    violações em tempo de compilação.
+support:
+  description: Disponível desde o Spring Framework 7.0 (requer Java 17+)

--- a/translations/content/pt-BR/enterprise/spring-xml-config-vs-annotations.yaml
+++ b/translations/content/pt-BR/enterprise/spring-xml-config-vs-annotations.yaml
@@ -1,0 +1,29 @@
+title: Configuração Spring XML vs Anotações
+oldApproach: Definições de beans em XML
+modernApproach: Beans orientados a anotações
+summary: Substitua definições verbosas de beans Spring em XML por configuração concisa
+  orientada a anotações no Spring Boot.
+explanation: Aplicações Spring tradicionais conectavam beans através de arquivos de
+  configuração XML, declarando cada classe e suas dependências como elementos <bean>
+  verbosos. Embora o suporte a anotações existisse desde o Spring 2.5, o XML permaneceu
+  a abordagem dominante até o Spring Boot introduzir a auto-configuração. O Spring
+  Boot detecta beans anotados com @Component, @Service, @Repository e @Controller
+  via classpath scanning, satisfaz dependências automaticamente por injeção via construtor
+  e configura infraestrutura como DataSource a partir do classpath — eliminando todos
+  os arquivos de configuração XML.
+whyModernWins:
+- icon: "🚫"
+  title: Sem XML
+  desc: "@SpringBootApplication dispara component scanning e auto-configuração, eliminando
+    todos os arquivos de configuração XML."
+- icon: "💉"
+  title: Injeção via construtor
+  desc: O Spring injeta dependências via construtores automaticamente, tornando os
+    beans mais fáceis de testar e entender.
+- icon: "⚡"
+  title: Auto-configuração
+  desc: O Spring Boot configura DataSource, JPA e outras infraestruturas a partir do
+    classpath sem nenhum boilerplate.
+support:
+  description: "Amplamente disponível desde o Spring Boot 1.0 (abril de 2014); Spring
+    Boot 3 requer Java 17+"

--- a/translations/content/pt-BR/errors/helpful-npe.yaml
+++ b/translations/content/pt-BR/errors/helpful-npe.yaml
@@ -1,0 +1,19 @@
+title: NullPointerExceptions detalhadas
+oldApproach: NPE críptica
+modernApproach: NPE detalhada
+summary: A JVM informa exatamente qual variável era null — sem adivinhação.
+explanation: As NPEs detalhadas descrevem qual expressão era null e qual operação
+  falhou. Isso é habilitado por padrão desde o Java 14 — não é necessário alterar código,
+  basta atualizar o JDK.
+whyModernWins:
+- icon: "🔍"
+  title: Variável exata
+  desc: A mensagem identifica a variável null na cadeia de chamadas.
+- icon: "⚡"
+  title: Depuração mais rápida
+  desc: Chega de adivinhar qual das 5 chamadas encadeadas era null.
+- icon: "🆓"
+  title: Atualização gratuita
+  desc: Nenhuma alteração de código — basta executar no JDK 14+.
+support:
+  description: Amplamente disponível desde o JDK 14 (março de 2020)

--- a/translations/content/pt-BR/errors/multi-catch.yaml
+++ b/translations/content/pt-BR/errors/multi-catch.yaml
@@ -1,0 +1,18 @@
+title: Tratamento multi-catch de exceções
+oldApproach: Blocos catch separados
+modernApproach: Multi-catch
+summary: Capture múltiplos tipos de exceção em um único bloco catch.
+explanation: O multi-catch trata múltiplos tipos de exceção com o mesmo código. A variável
+  de exceção é efetivamente final, então você pode relançá-la sem precisar encapsular.
+whyModernWins:
+- icon: "📏"
+  title: DRY
+  desc: A mesma lógica de tratamento escrita uma vez em vez de três.
+- icon: "🔄"
+  title: Relançável
+  desc: A exceção capturada pode ser relançada com seu tipo preciso.
+- icon: "📖"
+  title: Fácil de ler
+  desc: Todos os tipos tratados ficam visíveis em um único lugar.
+support:
+  description: Amplamente disponível desde o JDK 7 (julho de 2011)

--- a/translations/content/pt-BR/errors/null-in-switch.yaml
+++ b/translations/content/pt-BR/errors/null-in-switch.yaml
@@ -1,0 +1,19 @@
+title: Caso null no switch
+oldApproach: Verificação antes do switch
+modernApproach: case null
+summary: Trate null diretamente como um caso do switch — sem verificação separada.
+explanation: O switch com pattern matching pode tratar null como um rótulo de caso.
+  Isso elimina a necessidade de uma verificação de null antes do switch e torna o
+  tratamento de null explícito e visível.
+whyModernWins:
+- icon: "🎯"
+  title: Explícito
+  desc: O tratamento de null fica visível diretamente no switch.
+- icon: "🛡️"
+  title: Sem NPE
+  desc: Fazer switch em um valor null não lança NullPointerException.
+- icon: "📐"
+  title: Tudo em um
+  desc: Todos os casos, incluindo null, em uma única expressão switch.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/errors/optional-chaining.yaml
+++ b/translations/content/pt-BR/errors/optional-chaining.yaml
@@ -1,0 +1,19 @@
+title: Encadeamento com Optional
+oldApproach: Verificações de null aninhadas
+modernApproach: Pipeline com Optional
+summary: Substitua verificações de null aninhadas por um pipeline com Optional.
+explanation: O Optional.map() encadeia valores que podem ser null, interrompendo no
+  primeiro null encontrado. O orElse() fornece o valor padrão. Isso elimina a pirâmide
+  de verificações de null aninhadas.
+whyModernWins:
+- icon: "🔗"
+  title: Encadeável
+  desc: Cada .map() trata null de forma transparente.
+- icon: "📖"
+  title: Fluxo linear
+  desc: Leia da esquerda para a direita em vez de blocos if aninhados.
+- icon: "🛡️"
+  title: À prova de NPE
+  desc: null é tratado em cada etapa — nenhuma falha possível.
+support:
+  description: "Disponível desde o JDK 8+ (melhorado no 9+)"

--- a/translations/content/pt-BR/errors/optional-orelsethrow.yaml
+++ b/translations/content/pt-BR/errors/optional-orelsethrow.yaml
@@ -1,0 +1,20 @@
+title: Optional.orElseThrow() sem supplier
+oldApproach: get() ou orElseThrow(supplier)
+modernApproach: orElseThrow()
+summary: Use Optional.orElseThrow() como alternativa mais clara e expressiva ao get().
+explanation: O Optional.get() é amplamente considerado um code smell porque oculta
+  a possibilidade de falha. O orElseThrow() sem argumentos, adicionado no Java 10,
+  faz exatamente a mesma coisa, mas torna a intenção explícita — o desenvolvedor
+  espera um valor e quer uma exceção se estiver ausente.
+whyModernWins:
+- icon: "📖"
+  title: Autodocumentado
+  desc: orElseThrow() sinaliza claramente que a ausência é inesperada.
+- icon: "🔒"
+  title: Evita get()
+  desc: Ferramentas de análise estática marcam get() como arriscado; orElseThrow() é idiomático.
+- icon: "⚡"
+  title: Menos boilerplate
+  desc: Não é necessário passar um supplier para a NoSuchElementException padrão.
+support:
+  description: Disponível desde o JDK 10 (março de 2018).

--- a/translations/content/pt-BR/errors/record-based-errors.yaml
+++ b/translations/content/pt-BR/errors/record-based-errors.yaml
@@ -1,0 +1,19 @@
+title: Respostas de erro baseadas em records
+oldApproach: Map ou classe verbosa
+modernApproach: Records de erro
+summary: Use records para tipos de resposta de erro concisos e imutáveis.
+explanation: Records são perfeitos para respostas de erro — são imutáveis, possuem
+  equals/hashCode integrados para comparação e toString para logging. Construtores
+  personalizados adicionam validação ou valores padrão.
+whyModernWins:
+- icon: "📏"
+  title: Conciso
+  desc: Defina tipos de erro em 3 linhas em vez de 30.
+- icon: "🔒"
+  title: Imutável
+  desc: Os dados de erro não podem ser modificados acidentalmente após a criação.
+- icon: "📋"
+  title: toString automático
+  desc: Perfeito para logging — exibe todos os campos automaticamente.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/errors/require-nonnull-else.yaml
+++ b/translations/content/pt-BR/errors/require-nonnull-else.yaml
@@ -1,0 +1,19 @@
+title: Objects.requireNonNullElse()
+oldApproach: Verificação de null com ternário
+modernApproach: requireNonNullElse()
+summary: Obtenha um valor não-null com um padrão claro, sem precisar de ternário.
+explanation: O requireNonNullElse retorna o primeiro argumento se não for null, caso
+  contrário retorna o segundo. O valor padrão também não pode ser null — ele lança
+  NPE se ambos forem null, capturando bugs antecipadamente.
+whyModernWins:
+- icon: "📖"
+  title: Intenção clara
+  desc: O nome do método descreve exatamente o que ele faz.
+- icon: "🛡️"
+  title: Padrão null-safe
+  desc: O valor padrão também é verificado contra null.
+- icon: "📏"
+  title: Legível
+  desc: Melhor que ternário para lógica simples de null-ou-padrão.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/io/deserialization-filters.yaml
+++ b/translations/content/pt-BR/io/deserialization-filters.yaml
@@ -1,0 +1,19 @@
+modernApproach: ObjectInputFilter
+summary: Restrinja quais classes podem ser desserializadas para prevenir ataques.
+title: Filtros de desserialização
+oldApproach: Aceitar tudo
+explanation: ObjectInputFilter permite criar listas de permissão/bloqueio de classes,
+  limitar a profundidade do grafo de objetos, tamanhos de arrays e contagem de referências.
+  Isso protege contra vulnerabilidades de desserialização sem bibliotecas externas.
+whyModernWins:
+- icon: 🛡️
+  title: Segurança
+  desc: Previne a desserialização de classes inesperadas ou maliciosas.
+- icon: 📐
+  title: Controle refinado
+  desc: Controle de profundidade, tamanho de arrays, referências e padrões de classes.
+- icon: 🏗️
+  title: Abrangência na JVM
+  desc: Defina um filtro global para toda desserialização na JVM.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/io/file-memory-mapping.yaml
+++ b/translations/content/pt-BR/io/file-memory-mapping.yaml
@@ -1,0 +1,20 @@
+modernApproach: MemorySegment com Arena
+summary: Mapeie arquivos maiores que 2GB com limpeza determinística usando MemorySegment.
+title: Mapeamento de arquivos em memória
+oldApproach: MappedByteBuffer
+explanation: A API Foreign Function & Memory (JEP 454) introduz o MemorySegment para
+  acesso seguro e eficiente à memória. Diferente do MappedByteBuffer, o MemorySegment
+  suporta arquivos maiores que 2GB (Integer.MAX_VALUE), oferece limpeza determinística
+  via Arena e melhor desempenho com hardware moderno.
+whyModernWins:
+- icon: 📏
+  title: Sem limite de tamanho
+  desc: Mapeie arquivos maiores que 2GB sem soluções alternativas.
+- icon: 🔒
+  title: Limpeza determinística
+  desc: Arena garante que a memória é liberada ao sair do escopo, não pelo GC.
+- icon: ⚡
+  title: Melhor desempenho
+  desc: Alinhado com modelos de memória e hardware modernos.
+support:
+  description: Disponível desde o JDK 22 (março de 2024)

--- a/translations/content/pt-BR/io/files-mismatch.yaml
+++ b/translations/content/pt-BR/io/files-mismatch.yaml
@@ -1,0 +1,19 @@
+modernApproach: Files.mismatch()
+summary: Compare dois arquivos de forma eficiente sem carregá-los na memória.
+title: Files.mismatch()
+oldApproach: Comparação manual de bytes
+explanation: Files.mismatch() retorna a posição do primeiro byte que difere, ou -1 se
+  os arquivos são idênticos. A leitura é feita de forma lazy e interrompe na primeira
+  diferença encontrada.
+whyModernWins:
+- icon: ⚡
+  title: Eficiente em memória
+  desc: Não carrega arquivos inteiros em arrays de bytes.
+- icon: 🎯
+  title: Localiza a diferença
+  desc: Retorna a posição exata do byte da primeira divergência.
+- icon: 📏
+  title: Uma chamada
+  desc: Sem lógica manual de comparação de arrays de bytes.
+support:
+  description: Amplamente disponível desde o JDK 12 (março de 2019)

--- a/translations/content/pt-BR/io/http-client.yaml
+++ b/translations/content/pt-BR/io/http-client.yaml
@@ -1,0 +1,19 @@
+modernApproach: HttpClient
+summary: Use o HttpClient integrado para requisições HTTP limpas e modernas.
+title: Cliente HTTP moderno
+oldApproach: HttpURLConnection
+explanation: HttpClient suporta HTTP/1.1 e HTTP/2, requisições assíncronas, WebSocket,
+  executors customizados e pool de conexões. Chega de fazer cast de URLConnection ou
+  ler InputStreams manualmente.
+whyModernWins:
+- icon: 📐
+  title: API Builder
+  desc: Builder fluente para requisições, cabeçalhos e timeouts.
+- icon: 🔄
+  title: Suporte a HTTP/2
+  desc: HTTP/2 integrado com multiplexação e server push.
+- icon: ⚡
+  title: Pronto para async
+  desc: sendAsync() retorna CompletableFuture.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/io/inputstream-transferto.yaml
+++ b/translations/content/pt-BR/io/inputstream-transferto.yaml
@@ -1,0 +1,18 @@
+modernApproach: transferTo()
+summary: Copie um InputStream para um OutputStream em uma única chamada.
+title: InputStream.transferTo()
+oldApproach: Loop de cópia manual
+explanation: transferTo() lê todos os bytes do stream de entrada e os escreve no stream
+  de saída. Sem gerenciamento de buffer, sem loop. Utiliza um buffer interno otimizado.
+whyModernWins:
+- icon: 📏
+  title: Uma linha
+  desc: Substitua todo o loop de leitura/escrita por uma única chamada de método.
+- icon: ⚡
+  title: Otimizado
+  desc: O tamanho do buffer interno é ajustado para melhor desempenho.
+- icon: 🛡️
+  title: Sem bugs
+  desc: Sem erros de off-by-one no gerenciamento de buffer.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/io/io-class-console-io.yaml
+++ b/translations/content/pt-BR/io/io-class-console-io.yaml
@@ -1,0 +1,25 @@
+modernApproach: Classe IO
+summary: A nova classe IO oferece métodos simples e concisos para entrada e saída no
+  console.
+title: Classe IO para I/O de console
+oldApproach: System.out / Scanner
+explanation: O Java 25 introduz a classe IO (java.io.IO) como parte do recurso de classes
+  declaradas implicitamente. Ela fornece métodos estáticos como println(), print(),
+  readln() e read() que substituem a combinação verbosa de System.out e Scanner.
+  IO.readln(prompt) trata tanto a exibição do prompt quanto a leitura em uma única
+  chamada. A classe está disponível automaticamente em arquivos-fonte compactos e pode
+  ser usada em classes tradicionais via import.
+whyModernWins:
+- icon: ✨
+  title: Drasticamente mais simples
+  desc: Dois métodos substituem sete linhas de configuração, leitura e limpeza do Scanner.
+- icon: 🔒
+  title: Sem vazamento de recursos
+  desc: Sem Scanner para fechar — os métodos de IO gerenciam os recursos internamente.
+- icon: 🎓
+  title: Amigável para iniciantes
+  desc: Novos desenvolvedores podem fazer I/O de console sem aprender Scanner, System.out
+    ou instruções de import.
+support:
+  description: Preview no JDK 25 como parte de classes declaradas implicitamente (JEP
+    495)

--- a/translations/content/pt-BR/io/path-of.yaml
+++ b/translations/content/pt-BR/io/path-of.yaml
@@ -1,0 +1,19 @@
+modernApproach: Path.of()
+summary: "Use Path.of() — o método fábrica moderno na interface Path."
+title: Método fábrica Path.of()
+oldApproach: Paths.get()
+explanation: Path.of() é um método fábrica adicionado diretamente à interface Path,
+  substituindo a classe utilitária separada Paths. É mais fácil de encontrar e consistente
+  com List.of(), Map.of(), etc.
+whyModernWins:
+- icon: 📐
+  title: API consistente
+  desc: Segue o padrão de fábrica .of() como List.of(), Set.of().
+- icon: 📖
+  title: Fácil de encontrar
+  desc: Disponível no próprio tipo Path, não em uma classe Paths separada.
+- icon: 🧹
+  title: Uma classe a menos
+  desc: Não é necessário importar a classe utilitária Paths.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/io/reading-files.yaml
+++ b/translations/content/pt-BR/io/reading-files.yaml
@@ -1,0 +1,19 @@
+modernApproach: Files.readString()
+summary: Leia um arquivo inteiro em uma String com uma única linha.
+title: Leitura de arquivos
+oldApproach: BufferedReader
+explanation: Files.readString() lê todo o conteúdo de um arquivo em uma String. Trata
+  a codificação (UTF-8 por padrão) e a limpeza de recursos. Para arquivos grandes,
+  use Files.lines() para streaming lazy.
+whyModernWins:
+- icon: 📏
+  title: Uma linha
+  desc: Substitua 8 linhas de boilerplate com BufferedReader.
+- icon: 🧹
+  title: Limpeza automática
+  desc: O handle do arquivo é fechado automaticamente.
+- icon: 🌐
+  title: UTF-8 por padrão
+  desc: Codificação correta por padrão — sem confusão de charset.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/io/try-with-resources-effectively-final.yaml
+++ b/translations/content/pt-BR/io/try-with-resources-effectively-final.yaml
@@ -1,0 +1,19 @@
+modernApproach: Effectively Final
+summary: Use variáveis efetivamente finais diretamente no try-with-resources.
+title: Melhoria no try-with-resources
+oldApproach: Redeclarar variável
+explanation: O Java 9 permite que variáveis efetivamente finais sejam usadas diretamente
+  no try-with-resources sem redeclaração. Isso é mais limpo quando o recurso foi
+  criado fora do bloco try.
+whyModernWins:
+- icon: 🧹
+  title: Sem redeclaração
+  desc: Use o nome da variável existente diretamente.
+- icon: 📖
+  title: Menos confusão
+  desc: Sem nome de variável separado dentro do bloco try.
+- icon: 📏
+  title: Conciso
+  desc: Menos linhas, mesma segurança de recursos.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/io/writing-files.yaml
+++ b/translations/content/pt-BR/io/writing-files.yaml
@@ -1,0 +1,18 @@
+modernApproach: Files.writeString()
+summary: Escreva uma String em um arquivo com uma única linha.
+title: Escrita de arquivos
+oldApproach: FileWriter + BufferedWriter
+explanation: Files.writeString() escreve conteúdo em um arquivo com codificação UTF-8
+  por padrão. Opções podem ser passadas para append, criação, etc.
+whyModernWins:
+- icon: 📏
+  title: Uma linha
+  desc: Sem encapsulamento de writers ou try-with-resources necessário.
+- icon: 🛡️
+  title: Padrões seguros
+  desc: Codificação UTF-8, limpeza adequada do handle de arquivo.
+- icon: 🔧
+  title: Opções
+  desc: Passe flags de OpenOption para append, criação, etc.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/language/compact-canonical-constructor.yaml
+++ b/translations/content/pt-BR/language/compact-canonical-constructor.yaml
@@ -1,0 +1,20 @@
+title: Construtor canônico compacto
+oldApproach: Validação explícita no construtor
+modernApproach: Construtor compacto
+summary: Valide e normalize campos de records sem repetir a lista de parâmetros.
+explanation: Records podem declarar um construtor canônico compacto que omite a lista
+  de parâmetros e as atribuições de campos. O compilador atribui automaticamente os
+  parâmetros aos campos após a execução da lógica de validação. Ideal para verificações
+  de pré-condições, cópias defensivas e normalização.
+whyModernWins:
+- icon: "✂️"
+  title: Menos repetição
+  desc: Não é necessário repetir a lista de parâmetros nem atribuir cada campo manualmente.
+- icon: "🛡️"
+  title: Validação
+  desc: Perfeito para verificações de nulo, validação de faixa e cópias defensivas.
+- icon: "📖"
+  title: Intenção mais clara
+  desc: A sintaxe compacta enfatiza a validação, não o boilerplate.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/language/compact-source-files.yaml
+++ b/translations/content/pt-BR/language/compact-source-files.yaml
@@ -1,0 +1,20 @@
+title: Arquivos-fonte compactos
+oldApproach: Cerimônia da classe Main
+modernApproach: void main()
+summary: Escreva um programa completo sem declaração de classe ou public static void
+  main.
+explanation: Arquivos-fonte compactos eliminam a cerimônia de declarações de classe
+  e da assinatura do método main para programas simples. Combinado com o import implícito
+  de java.io.IO, até o println fica disponível diretamente.
+whyModernWins:
+- icon: "🚀"
+  title: Zero cerimônia
+  desc: Sem classe, sem public static void main, sem String[] args.
+- icon: "🎓"
+  title: Amigável para iniciantes
+  desc: Novos programadores podem escrever código útil desde a primeira linha.
+- icon: "📝"
+  title: Estilo script
+  desc: Perfeito para protótipos rápidos, scripts e exemplos.
+support:
+  description: Finalizado no JDK 25 LTS (JEP 512, set 2025).

--- a/translations/content/pt-BR/language/default-interface-methods.yaml
+++ b/translations/content/pt-BR/language/default-interface-methods.yaml
@@ -1,0 +1,23 @@
+title: Métodos default em interfaces
+oldApproach: Classes abstratas para comportamento compartilhado
+modernApproach: Métodos default em interfaces
+summary: Adicione implementações de métodos diretamente em interfaces, permitindo herança
+  múltipla de comportamento.
+explanation: Antes do Java 8, compartilhar comportamento entre classes não relacionadas
+  exigia classes abstratas, o que limitava à herança simples. Métodos default permitem
+  que interfaces forneçam implementações de métodos, para que classes herdem comportamento
+  de múltiplas interfaces. Isso foi essencial para evoluir a API de Collections (ex.
+  List.forEach, Map.getOrDefault) sem quebrar implementações existentes.
+whyModernWins:
+- icon: "🔀"
+  title: Herança múltipla
+  desc: Classes podem implementar várias interfaces com métodos default, diferente da
+    herança simples de classes abstratas.
+- icon: "📦"
+  title: Evolução de APIs
+  desc: Adicione novos métodos a interfaces sem quebrar implementações existentes.
+- icon: "🧩"
+  title: Comportamento combinável
+  desc: Combine e misture capacidades de múltiplas interfaces livremente.
+support:
+  description: Disponível desde o JDK 8 (março de 2014).

--- a/translations/content/pt-BR/language/diamond-operator.yaml
+++ b/translations/content/pt-BR/language/diamond-operator.yaml
@@ -1,0 +1,19 @@
+title: Diamond com classes anônimas
+oldApproach: Repetir argumentos de tipo
+modernApproach: Diamond <>
+summary: O operador diamond agora funciona também com classes anônimas.
+explanation: O Java 7 introduziu o <>, mas ele não funcionava com classes internas anônimas.
+  O Java 9 corrigiu isso, então você nunca mais precisa repetir argumentos de tipo
+  no lado direito.
+whyModernWins:
+- icon: "📏"
+  title: Regras consistentes
+  desc: O diamond funciona em todos os lugares — construtores e classes anônimas.
+- icon: "🧹"
+  title: Menos redundância
+  desc: Argumentos de tipo são declarados uma vez à esquerda, nunca repetidos.
+- icon: "🔧"
+  title: Princípio DRY
+  desc: O compilador já sabe o tipo — por que escrevê-lo duas vezes?
+support:
+  description: Diamond com classes anônimas desde o JDK 9 (set 2017).

--- a/translations/content/pt-BR/language/exhaustive-switch.yaml
+++ b/translations/content/pt-BR/language/exhaustive-switch.yaml
@@ -1,0 +1,20 @@
+title: Switch exaustivo sem default
+oldApproach: Default obrigatório
+modernApproach: Exaustividade com sealed
+summary: O compilador verifica que todos os subtipos sealed estão cobertos — sem necessidade
+  de default.
+explanation: Ao fazer switch sobre um tipo sealed, o compilador conhece todos os subtipos
+  possíveis e verifica que cada caso está tratado. Se você adicionar um novo subtipo,
+  o compilador aponta cada switch que ficou incompleto.
+whyModernWins:
+- icon: "✅"
+  title: Segurança em tempo de compilação
+  desc: Adicione um novo subtipo e o compilador mostra cada lugar a ser atualizado.
+- icon: "🚫"
+  title: Sem código morto
+  desc: Sem branch default inalcançável que mascara bugs.
+- icon: "📐"
+  title: Tipos algébricos
+  desc: "sealed + records + switch exaustivo = ADTs completos em Java."
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (set 2023)

--- a/translations/content/pt-BR/language/flexible-constructor-bodies.yaml
+++ b/translations/content/pt-BR/language/flexible-constructor-bodies.yaml
@@ -1,0 +1,19 @@
+title: Corpos de construtores flexíveis
+oldApproach: Validar após super()
+modernApproach: Código antes de super()
+summary: Valide e compute valores antes de chamar super() ou this().
+explanation: O Java 25 remove a restrição de que super() deve ser a primeira instrução.
+  Agora você pode validar argumentos, computar valores derivados e preparar estado
+  antes de delegar ao construtor da classe pai.
+whyModernWins:
+- icon: "🛡️"
+  title: Falha rápida
+  desc: Valide argumentos antes do construtor da superclasse executar.
+- icon: "🧮"
+  title: Compute primeiro
+  desc: Derive valores e prepare dados antes de chamar super().
+- icon: "🧹"
+  title: Sem workarounds
+  desc: Chega de métodos auxiliares estáticos ou padrões factory para contornar a restrição.
+support:
+  description: Finalizado no JDK 25 LTS (JEP 513, set 2025).

--- a/translations/content/pt-BR/language/guarded-patterns.yaml
+++ b/translations/content/pt-BR/language/guarded-patterns.yaml
@@ -1,0 +1,19 @@
+title: Padrões com guardas usando when
+oldApproach: if aninhado
+modernApproach: Cláusula when
+summary: Adicione condições aos cases de padrões usando guardas when.
+explanation: Padrões com guardas permitem refinar uma correspondência de tipo com uma
+  condição booleana adicional. Isso mantém toda a lógica de ramificação no switch em
+  vez de aninhar instruções if dentro dos cases.
+whyModernWins:
+- icon: "🎯"
+  title: Correspondência precisa
+  desc: Combine tipo + condição em um único rótulo de case.
+- icon: "📐"
+  title: Estrutura plana
+  desc: Sem if/else aninhado dentro dos cases do switch.
+- icon: "📖"
+  title: Intenção legível
+  desc: A cláusula when se lê como linguagem natural.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (set 2023)

--- a/translations/content/pt-BR/language/markdown-javadoc-comments.yaml
+++ b/translations/content/pt-BR/language/markdown-javadoc-comments.yaml
@@ -1,0 +1,20 @@
+title: Markdown em comentários Javadoc
+oldApproach: Javadoc baseado em HTML
+modernApproach: Javadoc com Markdown
+summary: Escreva comentários Javadoc em Markdown em vez de HTML para melhor legibilidade.
+explanation: O Java 23 introduz comentários Javadoc no estilo Markdown com /// como
+  alternativa ao formato tradicional /** */ baseado em HTML. A sintaxe Markdown é mais
+  natural para escrever e ler, com suporte a blocos de código, ênfase, listas e links.
+  O compilador converte o Markdown para HTML na saída do javadoc.
+whyModernWins:
+- icon: "📖"
+  title: Sintaxe natural
+  desc: "Use crases para código inline e ``` para blocos em vez de tags HTML."
+- icon: "✍️"
+  title: Mais fácil de escrever
+  desc: "Sem necessidade de {@code}, <pre>, <p> — basta escrever Markdown."
+- icon: "👁"
+  title: Melhor em editores
+  desc: Markdown renderiza lindamente em IDEs e editores de texto modernos.
+support:
+  description: Disponível desde o JDK 23 (set 2024)

--- a/translations/content/pt-BR/language/module-import-declarations.yaml
+++ b/translations/content/pt-BR/language/module-import-declarations.yaml
@@ -1,0 +1,19 @@
+title: Declarações de import por módulo
+oldApproach: Muitos imports
+modernApproach: import module
+summary: Importe todos os pacotes exportados de um módulo com uma única declaração.
+explanation: Declarações de import por módulo permitem importar tudo que um módulo exporta
+  com uma linha. Isso é especialmente útil para java.base, que cobre collections,
+  I/O, streams e mais.
+whyModernWins:
+- icon: "🧹"
+  title: Uma linha
+  desc: Substitua uma parede de imports por um único import de módulo.
+- icon: "📦"
+  title: Consciente de módulos
+  desc: Aproveita o sistema de módulos para importar conjuntos coerentes de pacotes.
+- icon: "🚀"
+  title: Início rápido
+  desc: Perfeito para scripts e protótipos onde listas de import são tediosas.
+support:
+  description: Finalizado no JDK 25 LTS (JEP 511, set 2025).

--- a/translations/content/pt-BR/language/pattern-matching-instanceof.yaml
+++ b/translations/content/pt-BR/language/pattern-matching-instanceof.yaml
@@ -1,0 +1,19 @@
+title: Pattern matching para instanceof
+oldApproach: instanceof + Cast
+modernApproach: Variável de padrão
+summary: Combine verificação de tipo e cast em um único passo com pattern matching.
+explanation: O pattern matching para instanceof elimina o cast redundante após uma verificação
+  de tipo. A variável é automaticamente escopada para onde o padrão corresponde, tornando
+  o código mais seguro e conciso.
+whyModernWins:
+- icon: "🔄"
+  title: Sem cast redundante
+  desc: Verificação de tipo e vinculação de variável acontecem em uma única expressão.
+- icon: "📏"
+  title: Menos linhas
+  desc: Uma linha em vez de duas — a linha do cast desaparece completamente.
+- icon: "🛡️"
+  title: Segurança de escopo
+  desc: A variável de padrão só existe no escopo onde o tipo é garantido.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/language/pattern-matching-switch.yaml
+++ b/translations/content/pt-BR/language/pattern-matching-switch.yaml
@@ -1,0 +1,20 @@
+title: Pattern matching em switch
+oldApproach: Cadeia de if-else
+modernApproach: Padrões de tipo
+summary: Substitua cadeias de if-else com instanceof por padrões de tipo limpos no
+  switch.
+explanation: O pattern matching em switch permite corresponder tipos diretamente, combinando
+  o teste de tipo, cast e vinculação em um rótulo de case conciso. O compilador verifica
+  a completude.
+whyModernWins:
+- icon: "📐"
+  title: Despacho estruturado
+  desc: O switch torna a estrutura de ramificação explícita e fácil de ler.
+- icon: "🎯"
+  title: Forma de expressão
+  desc: Retorna um valor diretamente — sem necessidade de variável mutável.
+- icon: "✅"
+  title: Exaustividade
+  desc: O compilador garante que todos os tipos estão tratados.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (set 2023)

--- a/translations/content/pt-BR/language/primitive-types-in-patterns.yaml
+++ b/translations/content/pt-BR/language/primitive-types-in-patterns.yaml
@@ -1,0 +1,20 @@
+title: Tipos primitivos em padrões
+oldApproach: Verificações manuais de faixa
+modernApproach: Padrões primitivos
+summary: O pattern matching agora funciona com tipos primitivos, não apenas objetos.
+explanation: O Java 25 estende o pattern matching para tipos primitivos. Você pode usar
+  int, long, double etc. em padrões de switch com guardas when, eliminando a necessidade
+  de boxing ou verificações manuais de faixa.
+whyModernWins:
+- icon: "📦"
+  title: Sem boxing
+  desc: Faça correspondência de primitivos diretamente — sem necessidade do wrapper
+    Integer.
+- icon: "🎯"
+  title: Consistência de padrões
+  desc: Mesma sintaxe de padrões para objetos e primitivos.
+- icon: "⚡"
+  title: Melhor desempenho
+  desc: Evite o overhead de autoboxing no pattern matching.
+support:
+  description: Preview no JDK 25 (terceiro preview, JEP 507). Requer --enable-preview.

--- a/translations/content/pt-BR/language/private-interface-methods.yaml
+++ b/translations/content/pt-BR/language/private-interface-methods.yaml
@@ -1,0 +1,19 @@
+title: Métodos privados em interfaces
+oldApproach: Lógica duplicada
+modernApproach: Métodos privados
+summary: Extraia lógica compartilhada em interfaces usando métodos privados.
+explanation: O Java 9 permite métodos privados em interfaces, possibilitando compartilhar
+  código entre métodos default sem expor detalhes de implementação às classes que implementam
+  a interface.
+whyModernWins:
+- icon: "🧩"
+  title: Reuso de código
+  desc: Compartilhe lógica entre métodos default sem duplicação.
+- icon: "🔐"
+  title: Encapsulamento
+  desc: Detalhes de implementação ficam ocultos das classes que implementam a interface.
+- icon: "🧹"
+  title: Interfaces DRY
+  desc: Chega de copiar e colar entre métodos default.
+support:
+  description: Amplamente disponível desde o JDK 9 (set 2017)

--- a/translations/content/pt-BR/language/record-patterns.yaml
+++ b/translations/content/pt-BR/language/record-patterns.yaml
@@ -1,0 +1,19 @@
+title: Record patterns (desestruturação)
+oldApproach: Acesso manual
+modernApproach: Desestruturação
+summary: Desestruture records diretamente em padrões — extraia campos em um único passo.
+explanation: Record patterns permitem decompor os componentes de um record diretamente
+  em instanceof e switch. Padrões aninhados também são suportados, possibilitando correspondência
+  profunda sem variáveis intermediárias.
+whyModernWins:
+- icon: "🎯"
+  title: Extração direta
+  desc: Acesse componentes do record sem chamar acessores manualmente.
+- icon: "🪆"
+  title: Aninhável
+  desc: Padrões podem ser aninhados — corresponda records internos em uma única expressão.
+- icon: "📏"
+  title: Código compacto
+  desc: Cinco linhas viram duas — menos cerimônia, mesma clareza.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (set 2023)

--- a/translations/content/pt-BR/language/sealed-classes.yaml
+++ b/translations/content/pt-BR/language/sealed-classes.yaml
@@ -1,0 +1,19 @@
+title: Classes sealed para hierarquias de tipos
+oldApproach: Hierarquia aberta
+modernApproach: sealed permits
+summary: Restrinja quais classes podem estender um tipo — possibilitando switches exaustivos.
+explanation: Classes sealed definem um conjunto fechado de subtipos. O compilador conhece
+  todos os casos possíveis, permitindo pattern matching exaustivo sem um branch default.
+  Combinadas com records, elas modelam tipos de dados algébricos.
+whyModernWins:
+- icon: "🔐"
+  title: Hierarquia controlada
+  desc: Apenas subtipos permitidos podem estender — sem subclasses surpresa.
+- icon: "✅"
+  title: Correspondência exaustiva
+  desc: O compilador verifica que o switch cobre todos os casos, sem default necessário.
+- icon: "📐"
+  title: Tipos de dados algébricos
+  desc: "Modele tipos soma naturalmente — sealed + records = ADTs em Java."
+support:
+  description: Amplamente disponível desde o JDK 17 LTS (set 2021)

--- a/translations/content/pt-BR/language/static-members-in-inner-classes.yaml
+++ b/translations/content/pt-BR/language/static-members-in-inner-classes.yaml
@@ -1,0 +1,22 @@
+title: Membros estáticos em classes internas
+oldApproach: Necessário usar classe aninhada estática
+modernApproach: Membros estáticos em classes internas
+summary: Defina membros estáticos em classes internas sem precisar de classes aninhadas
+  estáticas.
+explanation: Antes do Java 16, apenas classes aninhadas estáticas podiam conter membros
+  estáticos. Classes internas (não estáticas) não podiam ter estáticos porque exigiam
+  uma instância envolvente. O Java 16 flexibiliza essa restrição, permitindo campos
+  estáticos, métodos e até tipos aninhados em classes internas.
+whyModernWins:
+- icon: "🔓"
+  title: Mais flexibilidade
+  desc: Classes internas agora podem ter membros estáticos quando necessário.
+- icon: "🧩"
+  title: Estado compartilhado
+  desc: Rastreie estado compartilhado entre instâncias de uma classe interna.
+- icon: "📐"
+  title: Liberdade de design
+  desc: Não é preciso promover para classe aninhada estática só por causa de um campo
+    estático.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/language/static-methods-in-interfaces.yaml
+++ b/translations/content/pt-BR/language/static-methods-in-interfaces.yaml
@@ -1,0 +1,21 @@
+title: Métodos estáticos em interfaces
+oldApproach: Classes utilitárias
+modernApproach: Métodos estáticos na interface
+summary: Adicione métodos utilitários estáticos diretamente em interfaces em vez de
+  classes utilitárias separadas.
+explanation: "Antes do Java 8, métodos utilitários relacionados a uma interface precisavam\
+  \ ficar em uma classe separada (ex.: Collections para Collection). Métodos estáticos\
+  \ em interfaces permitem manter utilitários relacionados juntos. Comum em APIs modernas\
+  \ como Comparator.comparing(), Stream.of() e List.of()."
+whyModernWins:
+- icon: "📦"
+  title: Melhor organização
+  desc: Mantenha utilitários relacionados na interface, não em uma classe separada.
+- icon: "🔍"
+  title: Descobribilidade
+  desc: Métodos factory e auxiliares são encontrados onde se espera.
+- icon: "🧩"
+  title: Coesão da API
+  desc: Sem necessidade de classes *Utils ou *Helper separadas.
+support:
+  description: Disponível desde o JDK 8 (março de 2014)

--- a/translations/content/pt-BR/language/switch-expressions.yaml
+++ b/translations/content/pt-BR/language/switch-expressions.yaml
@@ -1,0 +1,19 @@
+title: Expressões switch
+oldApproach: Instrução switch
+modernApproach: Expressão switch
+summary: Switch como expressão que retorna um valor — sem break, sem fall-through.
+explanation: Expressões switch retornam um valor diretamente, usam sintaxe de seta para
+  evitar bugs de fall-through, e o compilador verifica a exaustividade. Isso substitui
+  a forma de instrução propensa a erros.
+whyModernWins:
+- icon: "🎯"
+  title: Retorna um valor
+  desc: Atribua o resultado do switch diretamente — sem variável temporária necessária.
+- icon: "🛡️"
+  title: Sem fall-through
+  desc: A sintaxe de seta elimina bugs acidentais de fall-through por break esquecido.
+- icon: "✅"
+  title: Verificação de exaustividade
+  desc: O compilador garante que todos os casos estão cobertos.
+support:
+  description: Amplamente disponível desde o JDK 14 (março de 2020)

--- a/translations/content/pt-BR/language/text-blocks-for-multiline-strings.yaml
+++ b/translations/content/pt-BR/language/text-blocks-for-multiline-strings.yaml
@@ -1,0 +1,20 @@
+title: Text blocks para strings multilinha
+oldApproach: Concatenação de strings
+modernApproach: Text blocks
+summary: Escreva strings multilinha naturalmente com text blocks de aspas triplas.
+explanation: Text blocks permitem escrever strings multilinha exatamente como elas aparecem.
+  Chega de escapar aspas ou adicionar \n. O compilador remove a indentação acidental
+  automaticamente.
+whyModernWins:
+- icon: "📖"
+  title: Legível como está
+  desc: JSON, SQL e HTML parecem JSON, SQL e HTML reais no seu código-fonte.
+- icon: "🚫"
+  title: Sem inferno de escape
+  desc: Aspas embutidas não precisam de escape com barra invertida.
+- icon: "📐"
+  title: Indentação inteligente
+  desc: Espaços em branco iniciais são removidos automaticamente com base na posição
+    do delimitador de fechamento.
+support:
+  description: Amplamente disponível desde o JDK 15 (set 2020)

--- a/translations/content/pt-BR/language/unnamed-variables.yaml
+++ b/translations/content/pt-BR/language/unnamed-variables.yaml
@@ -1,0 +1,20 @@
+title: Variáveis sem nome com _
+oldApproach: Variável não utilizada
+modernApproach: Placeholder _
+summary: Use _ para sinalizar intenção quando uma variável é intencionalmente não utilizada.
+explanation: Variáveis sem nome comunicam a leitores e ferramentas que um valor é deliberadamente
+  ignorado. Chega de convenções de nomes como 'ignored' ou 'unused', chega de avisos
+  da IDE.
+whyModernWins:
+- icon: "📢"
+  title: Intenção clara
+  desc: "_ diz explicitamente 'este valor não é necessário aqui'."
+- icon: "🔇"
+  title: Sem avisos
+  desc: IDEs e linters não sinalizarão variáveis intencionalmente não utilizadas.
+- icon: "🧹"
+  title: Lambdas mais limpas
+  desc: Lambdas com múltiplos parâmetros ficam mais limpas quando você só precisa de
+    alguns.
+support:
+  description: Finalizado no JDK 22 (JEP 456, março de 2024).

--- a/translations/content/pt-BR/security/key-derivation-functions.yaml
+++ b/translations/content/pt-BR/security/key-derivation-functions.yaml
@@ -1,0 +1,19 @@
+title: Funções de Derivação de Chaves
+oldApproach: PBKDF2 manual
+modernApproach: API KDF
+summary: Derive chaves criptográficas usando a API padrão KDF.
+explanation: A API KDF fornece uma interface padrão para funções de derivação de chaves,
+  incluindo HKDF. Ela substitui o padrão desajeitado de SecretKeyFactory + PBEKeySpec
+  por uma API limpa com builder.
+whyModernWins:
+- icon: "📐"
+  title: API limpa
+  desc: Padrão builder no lugar de construtores KeySpec desajeitados.
+- icon: "🔧"
+  title: Suporte a HKDF
+  desc: Algoritmo moderno HKDF junto com PBKDF2.
+- icon: "🛡️"
+  title: Padronizado
+  desc: API unificada para todos os algoritmos de derivação de chaves.
+support:
+  description: Finalizado no JDK 25 LTS (JEP 510, setembro de 2025).

--- a/translations/content/pt-BR/security/pem-encoding.yaml
+++ b/translations/content/pt-BR/security/pem-encoding.yaml
@@ -1,0 +1,19 @@
+title: Codificação/decodificação PEM
+oldApproach: Base64 manual + cabeçalhos
+modernApproach: API PEM
+summary: Codifique e decodifique objetos criptográficos em formato PEM nativamente.
+explanation: A API PEM fornece codificação/decodificação padrão para certificados,
+  chaves e outros objetos criptográficos no formato PEM. Chega de envolver Base64
+  manualmente com cabeçalhos BEGIN/END.
+whyModernWins:
+- icon: "🧹"
+  title: Sem Base64 manual
+  desc: Cabeçalhos PEM, quebra de linha e Base64 tratados automaticamente.
+- icon: "🔄"
+  title: Bidirecional
+  desc: Codifique para PEM e decodifique de PEM com uma única API.
+- icon: "🛡️"
+  title: Formato padrão
+  desc: Produz saída PEM em conformidade com a RFC 7468.
+support:
+  description: Preview no JDK 25 (JEP 470). Requer --enable-preview.

--- a/translations/content/pt-BR/security/random-generator.yaml
+++ b/translations/content/pt-BR/security/random-generator.yaml
@@ -1,0 +1,21 @@
+title: Interface RandomGenerator
+oldApproach: new Random() / ThreadLocalRandom
+modernApproach: Factory RandomGenerator
+summary: Use a interface RandomGenerator para escolher algoritmos de números aleatórios
+  pelo nome sem acoplamento a uma classe específica.
+explanation: O JDK 17 introduziu RandomGenerator como uma interface comum para todas
+  as implementações de RNG. Em vez de fixar new Random() ou ThreadLocalRandom, você
+  pode selecionar algoritmos pelo nome via factory, facilitando a troca entre algoritmos
+  otimizados para diferentes casos de uso (velocidade, qualidade estatística, divisibilidade).
+whyModernWins:
+- icon: "🔧"
+  title: Agnóstico de algoritmo
+  desc: Escolha o melhor algoritmo de RNG pelo nome sem alterar a estrutura do código.
+- icon: "⚡"
+  title: Algoritmos melhores
+  desc: Acesso a geradores LXM modernos com propriedades estatísticas superiores.
+- icon: "🔗"
+  title: API unificada
+  desc: Uma interface cobre Random, ThreadLocalRandom, SplittableRandom e mais.
+support:
+  description: Disponível desde o JDK 17 (setembro de 2021, JEP 356).

--- a/translations/content/pt-BR/security/strong-random.yaml
+++ b/translations/content/pt-BR/security/strong-random.yaml
@@ -1,0 +1,19 @@
+title: Geração de números aleatórios fortes
+oldApproach: new SecureRandom()
+modernApproach: getInstanceStrong()
+summary: Obtenha a implementação mais forte de SecureRandom da plataforma.
+explanation: "getInstanceStrong() retorna a implementação de SecureRandom configurada\
+  \ como a mais forte na plataforma. Isso é controlado pela propriedade de segurança\
+  \ securerandom.strongAlgorithms."
+whyModernWins:
+- icon: "🛡️"
+  title: A mais forte disponível
+  desc: Seleciona automaticamente o melhor algoritmo para a plataforma.
+- icon: "📖"
+  title: Intenção explícita
+  desc: Comunica claramente que aleatoriedade forte é necessária.
+- icon: "🔧"
+  title: Configurável
+  desc: Administradores podem alterar o algoritmo forte via propriedades de segurança.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/security/tls-default.yaml
+++ b/translations/content/pt-BR/security/tls-default.yaml
@@ -1,0 +1,20 @@
+title: TLS 1.3 por padrão
+oldApproach: Configuração manual de TLS
+modernApproach: TLS 1.3 padrão
+summary: TLS 1.3 é habilitado por padrão — nenhuma configuração explícita de protocolo
+  é necessária.
+explanation: O Java 11 adicionou suporte a TLS 1.3 e o tornou o protocolo preferido.
+  O HttpClient o utiliza automaticamente. Chega de especificar manualmente versões
+  de protocolo para conexões seguras.
+whyModernWins:
+- icon: "🛡️"
+  title: Mais seguro
+  desc: TLS 1.3 remove suítes de cifras e padrões de handshake obsoletos.
+- icon: "⚡"
+  title: Handshake mais rápido
+  desc: TLS 1.3 completa em uma ida e volta em vez de duas.
+- icon: "🆓"
+  title: Zero configuração
+  desc: Seguro por padrão — sem necessidade de seleção explícita de protocolo.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/streams/collectors-flatmapping.yaml
+++ b/translations/content/pt-BR/streams/collectors-flatmapping.yaml
@@ -1,0 +1,19 @@
+title: Collectors.flatMapping()
+oldApproach: flatMap aninhado
+modernApproach: flatMapping()
+summary: Use flatMapping() para achatar elementos dentro de um collector de agrupamento.
+explanation: Collectors.flatMapping() aplica um mapeamento de um-para-muitos como
+  um collector downstream. É o equivalente em collector do Stream.flatMap() — útil
+  dentro de groupingBy ou partitioningBy.
+whyModernWins:
+- icon: "🧩"
+  title: Componível
+  desc: Funciona como collector downstream dentro de groupingBy.
+- icon: "📐"
+  title: Passagem única
+  desc: Achata e agrupa em uma única travessia do stream.
+- icon: "🔗"
+  title: Aninhável
+  desc: Combine com outros collectors downstream.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/streams/optional-ifpresentorelse.yaml
+++ b/translations/content/pt-BR/streams/optional-ifpresentorelse.yaml
@@ -1,0 +1,18 @@
+title: Optional.ifPresentOrElse()
+oldApproach: if/else com Optional
+modernApproach: ifPresentOrElse()
+summary: Trate os casos de presente e vazio do Optional em uma única chamada.
+explanation: ifPresentOrElse() recebe um Consumer para o caso presente e um Runnable
+  para o caso vazio. Evita o antipadrão isPresent/get.
+whyModernWins:
+- icon: "📏"
+  title: Expressão única
+  desc: Ambos os casos tratados em uma única chamada de método.
+- icon: "🚫"
+  title: Sem get()
+  desc: Elimina o padrão perigoso de isPresent() + get().
+- icon: "🔗"
+  title: Fluente
+  desc: Encadeia naturalmente após findUser() ou qualquer método que retorna Optional.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/streams/optional-or.yaml
+++ b/translations/content/pt-BR/streams/optional-or.yaml
@@ -1,0 +1,19 @@
+title: Fallback com Optional.or()
+oldApproach: Fallback aninhado
+modernApproach: "Encadeamento com .or()"
+summary: Encadeie fallbacks de Optional sem verificações aninhadas.
+explanation: Optional.or() retorna o Optional original se contiver um valor, caso contrário
+  avalia o supplier para obter um Optional alternativo. Os suppliers são lazy — só
+  são chamados quando necessário.
+whyModernWins:
+- icon: "🔗"
+  title: Encadeável
+  desc: Empilhe fallbacks em um pipeline legível.
+- icon: "⚡"
+  title: Avaliação lazy
+  desc: Os suppliers de fallback só executam quando necessário.
+- icon: "📖"
+  title: Declarativo
+  desc: "Lê-se como 'tente primário, ou secundário, ou padrão'."
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/streams/predicate-not.yaml
+++ b/translations/content/pt-BR/streams/predicate-not.yaml
@@ -1,0 +1,21 @@
+title: Predicate.not() para negação
+oldApproach: Negação com lambda
+modernApproach: Predicate.not()
+summary: Use Predicate.not() para negar referências de método de forma limpa, em vez
+  de escrever lambdas de encapsulamento.
+explanation: Antes do Java 11, negar uma referência de método exigia envolvê-la em
+  uma lambda. Predicate.not() permite negar qualquer predicado diretamente, mantendo
+  o código legível e consistente com o estilo de referência de método em todo o pipeline
+  do stream.
+whyModernWins:
+- icon: "👁"
+  title: Negação mais limpa
+  desc: Sem necessidade de envolver referências de método em lambdas apenas para negá-las.
+- icon: "🔗"
+  title: Componível
+  desc: Funciona com qualquer Predicate, permitindo encadeamentos limpos de predicados.
+- icon: "📖"
+  title: Leitura natural
+  desc: "Predicate.not(String::isBlank) lê-se de forma natural."
+support:
+  description: Disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/streams/stream-gatherers.yaml
+++ b/translations/content/pt-BR/streams/stream-gatherers.yaml
@@ -1,0 +1,19 @@
+title: Stream Gatherers
+oldApproach: Collector customizado
+modernApproach: gather()
+summary: Use gatherers para operações intermediárias customizadas em streams.
+explanation: Gatherers são uma nova operação intermediária de stream que pode expressar
+  transformações complexas como janelas deslizantes, grupos de tamanho fixo e operações
+  de scan que eram impossíveis com as operações padrão de stream.
+whyModernWins:
+- icon: "🧩"
+  title: Componível
+  desc: Gatherers compõem com outras operações de stream.
+- icon: "📦"
+  title: Operações embutidas
+  desc: "windowFixed, windowSliding, fold, scan prontos para uso."
+- icon: "🔧"
+  title: Extensível
+  desc: Escreva gatherers customizados para qualquer transformação intermediária.
+support:
+  description: Finalizado no JDK 24 (JEP 485, março de 2025)

--- a/translations/content/pt-BR/streams/stream-iterate-predicate.yaml
+++ b/translations/content/pt-BR/streams/stream-iterate-predicate.yaml
@@ -1,0 +1,19 @@
+title: Stream.iterate() com predicado
+oldApproach: iterate + limit
+modernApproach: iterate(seed, pred, op)
+summary: Use um predicado para encerrar a iteração — como um for-loop em forma de stream.
+explanation: "O Stream.iterate(seed, hasNext, next) com três argumentos funciona como\
+  \ um for-loop: seed é o início, hasNext determina quando parar e next produz o próximo\
+  \ valor."
+whyModernWins:
+- icon: "🎯"
+  title: Terminação natural
+  desc: Pare com base em uma condição, não em um limite arbitrário.
+- icon: "📐"
+  title: Equivalente ao for-loop
+  desc: "Mesma semântica que for(seed; hasNext; next)."
+- icon: "🛡️"
+  title: Sem risco de stream infinito
+  desc: O predicado garante a terminação.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/streams/stream-mapmulti.yaml
+++ b/translations/content/pt-BR/streams/stream-mapmulti.yaml
@@ -1,0 +1,19 @@
+title: Stream.mapMulti()
+oldApproach: flatMap + List
+modernApproach: mapMulti()
+summary: Emita zero ou mais elementos por entrada sem criar streams intermediários.
+explanation: mapMulti() é uma alternativa imperativa ao flatMap que evita a criação
+  de objetos Stream intermediários para cada elemento. É mais eficiente quando o mapeamento
+  produz um número pequeno de elementos.
+whyModernWins:
+- icon: "⚡"
+  title: Menos alocação
+  desc: Nenhum Stream intermediário criado por elemento.
+- icon: "🎯"
+  title: Estilo imperativo
+  desc: Use loops e condicionais diretamente.
+- icon: "📐"
+  title: Flexível
+  desc: Emita zero, um ou muitos elementos com controle total.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/streams/stream-of-nullable.yaml
+++ b/translations/content/pt-BR/streams/stream-of-nullable.yaml
@@ -1,0 +1,19 @@
+title: Stream.ofNullable()
+oldApproach: Verificação de null
+modernApproach: ofNullable()
+summary: Crie um stream de zero ou um elemento a partir de um valor anulável.
+explanation: Stream.ofNullable() retorna um stream de um único elemento se o valor
+  for não-nulo, ou um stream vazio se for null. Elimina o padrão de verificação ternária
+  de null.
+whyModernWins:
+- icon: "📏"
+  title: Conciso
+  desc: Uma chamada substitui o condicional ternário.
+- icon: "🔗"
+  title: Compatível com flatMap
+  desc: Perfeito dentro de flatMap para ignorar valores nulos.
+- icon: "🛡️"
+  title: Seguro contra null
+  desc: Sem risco de NPE — null se torna um stream vazio.
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/streams/stream-takewhile-dropwhile.yaml
+++ b/translations/content/pt-BR/streams/stream-takewhile-dropwhile.yaml
@@ -1,0 +1,19 @@
+title: Stream takeWhile / dropWhile
+oldApproach: Loop manual
+modernApproach: takeWhile/dropWhile
+summary: Pegue ou descarte elementos de um stream com base em um predicado.
+explanation: takeWhile() retorna elementos enquanto o predicado for verdadeiro e para
+  no primeiro falso. dropWhile() pula elementos enquanto for verdadeiro e retorna o
+  restante. Ambos funcionam melhor em streams ordenados.
+whyModernWins:
+- icon: "🎯"
+  title: Curto-circuito
+  desc: Para o processamento assim que o predicado falha.
+- icon: "🔗"
+  title: Compatível com pipeline
+  desc: Encadeie com outras operações de stream naturalmente.
+- icon: "📖"
+  title: Declarativo
+  desc: "takeWhile lê-se de forma natural: 'pegue enquanto for menor que 100'."
+support:
+  description: Amplamente disponível desde o JDK 9 (setembro de 2017)

--- a/translations/content/pt-BR/streams/stream-tolist.yaml
+++ b/translations/content/pt-BR/streams/stream-tolist.yaml
@@ -1,0 +1,18 @@
+title: Stream.toList()
+oldApproach: Collectors.toList()
+modernApproach: .toList()
+summary: O terminal toList() substitui o verboso collect(Collectors.toList()).
+explanation: Stream.toList() retorna uma lista não modificável. É equivalente a .collect(Collectors.toUnmodifiableList()),
+  mas muito mais curto. Nota — o resultado é imutável, diferente de Collectors.toList().
+whyModernWins:
+- icon: "📏"
+  title: 7 caracteres vs 24
+  desc: .toList() substitui .collect(Collectors.toList()).
+- icon: "🔒"
+  title: Imutável
+  desc: A lista resultante não pode ser modificada.
+- icon: "📖"
+  title: Fluente
+  desc: Lê-se naturalmente no final de um pipeline.
+support:
+  description: Amplamente disponível desde o JDK 16 (março de 2021)

--- a/translations/content/pt-BR/streams/virtual-thread-executor.yaml
+++ b/translations/content/pt-BR/streams/virtual-thread-executor.yaml
@@ -1,0 +1,19 @@
+title: Executor com virtual threads
+oldApproach: Pool fixo de threads
+modernApproach: Virtual Thread Executor
+summary: Use executors de virtual threads para concorrência leve e ilimitada.
+explanation: O executor de virtual threads cria uma nova virtual thread para cada tarefa.
+  Sem necessidade de dimensionar o pool — virtual threads são baratas o suficiente
+  para criar milhões delas.
+whyModernWins:
+- icon: "♾️"
+  title: Sem dimensionamento
+  desc: Sem tamanho de pool para ajustar — crie quantas threads precisar.
+- icon: "⚡"
+  title: Leve
+  desc: Virtual threads usam KB de memória, não MB.
+- icon: "🧹"
+  title: Auto-closeable
+  desc: try-with-resources gerencia o encerramento automaticamente.
+support:
+  description: Amplamente disponível desde o JDK 21 LTS (setembro de 2023)

--- a/translations/content/pt-BR/strings/string-chars-stream.yaml
+++ b/translations/content/pt-BR/strings/string-chars-stream.yaml
@@ -1,0 +1,19 @@
+title: Caracteres de String como stream
+oldApproach: Loop manual
+modernApproach: Stream com chars()
+summary: Processe caracteres de uma string como um pipeline de stream.
+explanation: String.chars() retorna um IntStream dos valores dos caracteres, permitindo
+  processamento funcional. Para suporte a Unicode, codePoints() lida corretamente
+  com caracteres suplementares.
+whyModernWins:
+- icon: "🔗"
+  title: Encadeável
+  desc: Use filter, map e collect em streams de caracteres.
+- icon: "📐"
+  title: Declarativo
+  desc: Descreva o que fazer, não como iterar.
+- icon: "🌐"
+  title: Preparado para Unicode
+  desc: codePoints() lida corretamente com emojis e caracteres suplementares.
+support:
+  description: Disponível desde o JDK 8+ (aprimorado no 9+)

--- a/translations/content/pt-BR/strings/string-formatted.yaml
+++ b/translations/content/pt-BR/strings/string-formatted.yaml
@@ -1,0 +1,19 @@
+title: String.formatted()
+oldApproach: String.format()
+modernApproach: formatted()
+summary: Chame formatted() diretamente na string de template.
+explanation: String.formatted() é um método de instância equivalente a String.format(),
+  mas chamado na própria string de formato. A leitura flui de forma mais natural da
+  esquerda para a direita.
+whyModernWins:
+- icon: "📖"
+  title: Leitura natural
+  desc: "Template.formatted(args) flui melhor do que String.format(template, args)."
+- icon: "🔗"
+  title: Encadeável
+  desc: Pode ser encadeado com outros métodos de string.
+- icon: "📏"
+  title: Menos verboso
+  desc: Elimina a chamada estática redundante de String.format().
+support:
+  description: Amplamente disponível desde o JDK 15 (setembro de 2020)

--- a/translations/content/pt-BR/strings/string-indent-transform.yaml
+++ b/translations/content/pt-BR/strings/string-indent-transform.yaml
@@ -1,0 +1,18 @@
+title: String.indent() e transform()
+oldApproach: Indentação manual
+modernApproach: indent() / transform()
+summary: Indente texto e encadeie transformações de string de forma fluente.
+explanation: indent(n) adiciona n espaços a cada linha. transform(fn) aplica qualquer
+  função e retorna o resultado, permitindo encadeamento fluente de operações com strings.
+whyModernWins:
+- icon: "📏"
+  title: Nativo
+  desc: Indentação é uma operação comum — agora é uma única chamada.
+- icon: "🔗"
+  title: Encadeável
+  desc: transform() permite pipelines fluentes em strings.
+- icon: "🧹"
+  title: Código limpo
+  desc: Sem divisão manual de linhas e loops com StringBuilder.
+support:
+  description: Amplamente disponível desde o JDK 12 (março de 2019)

--- a/translations/content/pt-BR/strings/string-isblank.yaml
+++ b/translations/content/pt-BR/strings/string-isblank.yaml
@@ -1,0 +1,18 @@
+title: String.isBlank()
+oldApproach: trim().isEmpty()
+modernApproach: isBlank()
+summary: Verifique strings em branco com uma única chamada de método.
+explanation: isBlank() retorna true se a string estiver vazia ou contiver apenas espaços
+  em branco, incluindo caracteres Unicode de espaço que trim() não detecta.
+whyModernWins:
+- icon: "📖"
+  title: Autodocumentado
+  desc: isBlank() diz exatamente o que verifica.
+- icon: "🌐"
+  title: Compatível com Unicode
+  desc: Lida com todos os espaços em branco Unicode, não apenas ASCII.
+- icon: "⚡"
+  title: Sem alocação
+  desc: Nenhuma string intermediária é criada após remoção de espaços.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/strings/string-lines.yaml
+++ b/translations/content/pt-BR/strings/string-lines.yaml
@@ -1,0 +1,20 @@
+title: String.lines() para divisão de linhas
+oldApproach: "split(\"\\\\n\")"
+modernApproach: lines()
+summary: Use String.lines() para dividir texto em um stream de linhas sem o custo
+  de regex.
+explanation: String.lines() retorna um Stream<String> de linhas divididas por \n,
+  \r ou \r\n. É mais eficiente e preguiçoso que split(), evita compilação de regex
+  e se integra naturalmente com a API de Streams para processamento adicional.
+whyModernWins:
+- icon: "⚡"
+  title: Streaming preguiçoso
+  desc: As linhas são produzidas sob demanda, não todas de uma vez como split().
+- icon: "🔧"
+  title: Quebras de linha universais
+  desc: "Lida com \\n, \\r e \\r\\n automaticamente sem regex."
+- icon: "🔗"
+  title: Integração com Streams
+  desc: Retorna um Stream para uso direto com filter, map e collect.
+support:
+  description: Disponível desde o JDK 11 (setembro de 2018).

--- a/translations/content/pt-BR/strings/string-repeat.yaml
+++ b/translations/content/pt-BR/strings/string-repeat.yaml
@@ -1,0 +1,19 @@
+title: String.repeat()
+oldApproach: Loop com StringBuilder
+modernApproach: repeat()
+summary: Repita uma string n vezes sem usar loop.
+explanation: String.repeat(int) retorna a string concatenada consigo mesma n vezes.
+  Lida com casos especiais elegantemente — repeat(0) retorna string vazia, repeat(1)
+  retorna a mesma string.
+whyModernWins:
+- icon: "📏"
+  title: Uma linha
+  desc: Substitua 5 linhas de código com StringBuilder por uma única chamada.
+- icon: "⚡"
+  title: Otimizado
+  desc: A implementação interna é otimizada para grandes repetições.
+- icon: "📖"
+  title: Intenção clara
+  desc: repeat(3) transmite o propósito imediatamente.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/strings/string-strip.yaml
+++ b/translations/content/pt-BR/strings/string-strip.yaml
@@ -1,0 +1,20 @@
+title: String.strip() vs trim()
+oldApproach: trim()
+modernApproach: strip()
+summary: "Use remoção de espaços compatível com Unicode: strip(), stripLeading() e
+  stripTrailing()."
+explanation: trim() remove apenas caracteres ≤ U+0020 (caracteres de controle ASCII
+  e espaço). strip() usa Character.isWhitespace(), que lida com espaços Unicode como
+  espaço não quebrável, espaço ideográfico, entre outros.
+whyModernWins:
+- icon: "🌐"
+  title: Correto para Unicode
+  desc: Lida com todos os caracteres de espaço em branco de todos os scripts.
+- icon: "🎯"
+  title: Direcional
+  desc: stripLeading() e stripTrailing() para remoção em apenas um lado.
+- icon: "🛡️"
+  title: Menos bugs
+  desc: Sem espaços em branco inesperados em textos internacionais.
+support:
+  description: Amplamente disponível desde o JDK 11 (setembro de 2018)

--- a/translations/content/pt-BR/tooling/aot-class-preloading.yaml
+++ b/translations/content/pt-BR/tooling/aot-class-preloading.yaml
@@ -1,0 +1,21 @@
+title: Pré-carregamento AOT de classes
+oldApproach: Cold Start a cada inicialização
+modernApproach: Cache AOT
+summary: Armazene em cache o carregamento e a compilação de classes para inicialização
+  instantânea.
+explanation: O pré-carregamento AOT de classes armazena em cache as classes carregadas
+  e vinculadas a partir de uma execução de treinamento. Nas inicializações seguintes,
+  as classes são carregadas do cache, pulando a verificação e vinculação. Combinado
+  com a compilação AOT, isso reduz drasticamente o tempo de inicialização.
+whyModernWins:
+- icon: "⚡"
+  title: Inicialização mais rápida
+  desc: Pula o carregamento, verificação e vinculação de classes.
+- icon: "📦"
+  title: Estado em cache
+  desc: A execução de treinamento captura o estado ideal das classes.
+- icon: "🔧"
+  title: Sem alterações no código
+  desc: Funciona com aplicações existentes — basta adicionar flags na JVM.
+support:
+  description: "Disponível como recurso padrão no JDK 25 LTS (JEPs 514/515, set 2025)."

--- a/translations/content/pt-BR/tooling/built-in-http-server.yaml
+++ b/translations/content/pt-BR/tooling/built-in-http-server.yaml
@@ -1,0 +1,26 @@
+title: Servidor HTTP integrado
+oldApproach: Servidor externo / Framework
+modernApproach: CLI jwebserver
+summary: O Java 18 inclui um servidor HTTP mínimo integrado para prototipagem e servir
+  arquivos.
+explanation: O JDK 18 adicionou um servidor HTTP simples e sem dependências, acessível
+  pela ferramenta de linha de comando jwebserver ou pela API SimpleFileServer. Ele
+  serve arquivos estáticos de um diretório sem necessidade de configuração. A ferramenta
+  CLI é ideal para prototipagem rápida, testes e compartilhamento de arquivos — sem
+  dependências externas ou frameworks. A API permite uso programático com handlers
+  personalizáveis e níveis de saída configuráveis.
+whyModernWins:
+- icon: "🚀"
+  title: Zero configuração
+  desc: Execute jwebserver em qualquer diretório — sem instalação, configuração ou
+    dependências.
+- icon: "📦"
+  title: Integrado ao JDK
+  desc: Incluído em toda instalação do JDK 18+, sempre disponível em qualquer máquina
+    com Java.
+- icon: "🧪"
+  title: Ideal para prototipagem
+  desc: Sirva arquivos estáticos instantaneamente para testar HTML, APIs ou desenvolvimento
+    front-end.
+support:
+  description: Disponível desde o JDK 18 (março de 2022)

--- a/translations/content/pt-BR/tooling/compact-object-headers.yaml
+++ b/translations/content/pt-BR/tooling/compact-object-headers.yaml
@@ -1,0 +1,20 @@
+title: Headers de objeto compactos
+oldApproach: Headers de 128 bits
+modernApproach: Headers de 64 bits
+summary: Reduza o tamanho do header de objetos pela metade para melhor densidade de
+  memória e uso de cache.
+explanation: Headers de objeto compactos reduzem o overhead por objeto de 128 bits
+  para 64 bits em plataformas de 64 bits. Isso economiza memória e melhora a utilização
+  do cache, especialmente para aplicações com muitos objetos pequenos.
+whyModernWins:
+- icon: "📦"
+  title: Headers 50% menores
+  desc: 8 bytes em vez de 16 por objeto.
+- icon: "⚡"
+  title: Melhor uso de cache
+  desc: Mais objetos cabem nas linhas de cache da CPU.
+- icon: "📊"
+  title: Maior densidade
+  desc: Acomode mais objetos no mesmo tamanho de heap.
+support:
+  description: Finalizado no JDK 25 LTS (JEP 519, set 2025).

--- a/translations/content/pt-BR/tooling/jfr-profiling.yaml
+++ b/translations/content/pt-BR/tooling/jfr-profiling.yaml
@@ -1,0 +1,20 @@
+title: JFR para profiling
+oldApproach: Profiler externo
+modernApproach: Java Flight Recorder
+summary: Faça profiling de qualquer aplicação Java com o Flight Recorder integrado —
+  sem ferramentas externas.
+explanation: O Java Flight Recorder (JFR) é uma ferramenta de profiling de baixo overhead
+  integrada à JVM. Ele captura eventos de CPU, memória, GC, I/O, threads e eventos
+  personalizados com impacto mínimo no desempenho (~1%).
+whyModernWins:
+- icon: "🆓"
+  title: Integrado
+  desc: Nenhum profiler externo para instalar ou licenciar.
+- icon: "⚡"
+  title: Baixo overhead
+  desc: "~1% de impacto no desempenho — seguro para produção."
+- icon: "📊"
+  title: Eventos ricos
+  desc: "CPU, memória, GC, threads, I/O, locks e eventos personalizados."
+support:
+  description: Amplamente disponível desde o JDK 9/11 (código aberto a partir do 11)

--- a/translations/content/pt-BR/tooling/jshell-prototyping.yaml
+++ b/translations/content/pt-BR/tooling/jshell-prototyping.yaml
@@ -1,0 +1,19 @@
+title: JShell para prototipagem
+oldApproach: Criar arquivo + compilar + executar
+modernApproach: REPL jshell
+summary: Experimente expressões Java interativamente sem criar arquivos.
+explanation: JShell é um Read-Eval-Print Loop para Java. Teste expressões, experimente
+  APIs e prototipe código sem criar arquivos, compilar ou escrever um método main.
+  Inclui autocompletar com Tab e documentação inline.
+whyModernWins:
+- icon: "⚡"
+  title: Feedback instantâneo
+  desc: Digite uma expressão e veja o resultado imediatamente.
+- icon: "📝"
+  title: Sem arquivos necessários
+  desc: Sem arquivos .java, sem etapa de compilação.
+- icon: "🔍"
+  title: Exploração de APIs
+  desc: O autocompletar com Tab ajuda a descobrir métodos e parâmetros.
+support:
+  description: Amplamente disponível desde o JDK 9 (set 2017)

--- a/translations/content/pt-BR/tooling/junit6-with-jspecify.yaml
+++ b/translations/content/pt-BR/tooling/junit6-with-jspecify.yaml
@@ -1,0 +1,28 @@
+title: JUnit 6 com null safety do JSpecify
+oldApproach: API sem anotações
+modernApproach: API @NullMarked
+summary: O JUnit 6 adota @NullMarked do JSpecify, tornando os contratos de nulidade
+  explícitos em toda a API de asserções.
+explanation: O JUnit 5 foi lançado sem anotações de nulidade padronizadas, deixando
+  os desenvolvedores adivinhando se parâmetros de asserção ou valores de retorno
+  poderiam ser nulos. O JUnit 6 adota o JSpecify em todo o seu módulo — a anotação
+  @NullMarked torna todos os tipos não anotados non-null por padrão, e @Nullable
+  marca as exceções. A classe Assertions anota explicitamente parâmetros como
+  assertNull(@Nullable Object actual) e fail(@Nullable String message), para que
+  IDEs e analisadores estáticos como NullAway e Error Prone detectem uso incorreto
+  de null em tempo de compilação em vez de em tempo de execução.
+whyModernWins:
+- icon: "📜"
+  title: Contratos explícitos
+  desc: "@NullMarked no módulo do JUnit 6 documenta a semântica de null diretamente
+    na API — sem necessidade de ler o código-fonte."
+- icon: "🛡️"
+  title: Segurança em tempo de compilação
+  desc: IDEs e analisadores alertam quando null é passado onde non-null é esperado,
+    detectando bugs antes dos testes rodarem.
+- icon: "🌐"
+  title: Padrão do ecossistema
+  desc: O JSpecify é adotado pelo Spring, Guava e outros — semântica de null consistente
+    em toda a sua stack.
+support:
+  description: Disponível desde o JUnit 6.0 (outubro de 2025, requer Java 17+)

--- a/translations/content/pt-BR/tooling/multi-file-source.yaml
+++ b/translations/content/pt-BR/tooling/multi-file-source.yaml
@@ -1,0 +1,20 @@
+title: Launcher de múltiplos arquivos-fonte
+oldApproach: Compilar tudo primeiro
+modernApproach: Source Launcher
+summary: Execute programas com múltiplos arquivos sem uma etapa explícita de compilação.
+explanation: O Java 22+ pode compilar automaticamente arquivos-fonte referenciados
+  ao executar a partir de um arquivo .java. Isso torna programas pequenos com múltiplos
+  arquivos tão fáceis de executar quanto scripts, sem precisar do Maven ou Gradle.
+whyModernWins:
+- icon: "🚀"
+  title: Zero configuração
+  desc: Nenhuma ferramenta de build necessária para pequenos programas com múltiplos
+    arquivos.
+- icon: "🔗"
+  title: Resolução automática
+  desc: Classes referenciadas são encontradas e compiladas automaticamente.
+- icon: "📝"
+  title: Como um script
+  desc: Execute programas com múltiplos arquivos como scripts.
+support:
+  description: Disponível desde o JDK 22 (março de 2024)

--- a/translations/content/pt-BR/tooling/single-file-execution.yaml
+++ b/translations/content/pt-BR/tooling/single-file-execution.yaml
@@ -1,0 +1,19 @@
+title: Execução de arquivo único
+oldApproach: Compilação em duas etapas
+modernApproach: Execução direta
+summary: Execute programas Java de arquivo único diretamente sem javac.
+explanation: O launcher do Java pode compilar e executar um único arquivo-fonte em um
+  só comando. Combinado com suporte a shebang no Unix, arquivos Java podem funcionar
+  como scripts. Nenhuma etapa separada de compilação é necessária.
+whyModernWins:
+- icon: "⚡"
+  title: Um único comando
+  desc: java File.java compila e executa em uma só etapa.
+- icon: "📝"
+  title: Como um script
+  desc: Adicione uma linha shebang para tornar arquivos .java scripts executáveis.
+- icon: "🎓"
+  title: Amigável para iniciantes
+  desc: Iniciantes executam código imediatamente sem aprender ferramentas de build.
+support:
+  description: Amplamente disponível desde o JDK 11 (set 2018)


### PR DESCRIPTION
## Summary

Completes the Brazilian Portuguese (pt-BR) content translations for all 112 pattern files across all 11 categories.

### Changes
- **109 new translation files** added under `translations/content/pt-BR/`
- Covers all categories: collections, concurrency, datetime, enterprise, errors, io, language, security, streams, strings, tooling
- Each file contains only translatable fields per the i18n spec (title, oldApproach, modernApproach, summary, explanation, whyModernWins, support.description)
- Code fields (oldCode/modernCode) are excluded per spec
- Technical terms and API names kept in English
- All files validated as proper YAML with correct structure

### Before
3/112 content files translated (2.8%)

### After  
112/112 content files translated (100%) ✅