### PR TITLE
Fix deploy workflow path triggers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'content/**/*.json'
+      - 'content/**'
+      - 'translations/**'
       - 'templates/**'
       - 'site/**'
   workflow_run:


### PR DESCRIPTION
The deploy workflow's push path filter had two issues:

1. **`content/**/*.json`** — content files migrated to YAML in PR #84, so this glob no longer matches. Changed to `content/**`.
2. **`translations/**` missing** — translation file changes (like PR #85) didn't trigger deploys. Added `translations/**`.

This is why PR #85 (pt-BR translations) didn't trigger a deploy.