### PR TITLE
Add "learn more →" text to index card arrow links

### DIFF
--- a/html-generators/generate.java
+++ b/html-generators/generate.java
@@ -366,7 +366,8 @@ String renderIndexCard(String tpl, Snippet s, String locale, Map<String, String>
             Map.entry("jdkVersion", s.jdkVersion()), Map.entry("cardHref", cardHref),
             Map.entry("cards.old", strings.getOrDefault("cards.old", "Old")),
             Map.entry("cards.modern", strings.getOrDefault("cards.modern", "Modern")),
-            Map.entry("cards.hoverHint", strings.getOrDefault("cards.hoverHint", "hover to see modern →"))));
+            Map.entry("cards.hoverHint", strings.getOrDefault("cards.hoverHint", "hover to see modern →")),
+            Map.entry("cards.learnMore", strings.getOrDefault("cards.learnMore", "learn more"))));
 }
 
 String renderWhyCards(String tpl, JsonNode whyList) {

--- a/templates/index-card.html
+++ b/templates/index-card.html
@@ -18,6 +18,6 @@
         </div>
         <div class="tip-card-footer">
           <span class="browser-support"><span class="dot"></span> JDK {{jdkVersion}}+</span>
-          <span class="arrow-link">→</span>
+          <span class="arrow-link">{{cards.learnMore}} →</span>
         </div>
       </a>

--- a/translations/strings/ar.yaml
+++ b/translations/strings/ar.yaml
@@ -47,6 +47,7 @@ cards:
   hoverHint: "مرر للرؤية الحديث ←"
   hoverHintRelated: "مرر للرؤية الحديث ←"
   touchHint: "👆 انقر أو اسحب ←"
+  learnMore: اعرف المزيد
 copy:
   copy: نسخ
   copied: "تم النسخ!"

--- a/translations/strings/de.yaml
+++ b/translations/strings/de.yaml
@@ -49,6 +49,7 @@ cards:
   hoverHint: Hover für Modernes →
   hoverHintRelated: Hover für Modernes ➜
   touchHint: 👆 tippen oder wischen →
+  learnMore: mehr erfahren
 copy:
   copy: Kopieren
   copied: Kopiert!

--- a/translations/strings/en.yaml
+++ b/translations/strings/en.yaml
@@ -49,6 +49,7 @@ cards:
   hoverHint: hover to see modern →
   hoverHintRelated: Hover to see modern ➜
   touchHint: 👆 tap or swipe →
+  learnMore: learn more
 copy:
   copy: Copy
   copied: Copied!

--- a/translations/strings/es.yaml
+++ b/translations/strings/es.yaml
@@ -49,6 +49,7 @@ cards:
   hoverHint: pasa el ratón para ver el moderno →
   hoverHintRelated: Pasa el ratón para ver el moderno ➜
   touchHint: 👆 toca o desliza →
+  learnMore: saber más
 copy:
   copy: Copiar
   copied: ¡Copiado!

--- a/translations/strings/fr.yaml
+++ b/translations/strings/fr.yaml
@@ -49,6 +49,7 @@ cards:
   hoverHint: survolez pour voir le moderne →
   hoverHintRelated: Survolez pour voir le moderne ➜
   touchHint: 👆 appuyez ou glissez →
+  learnMore: en savoir plus
 copy:
   copy: Copier
   copied: Copié !

--- a/translations/strings/ja.yaml
+++ b/translations/strings/ja.yaml
@@ -47,6 +47,7 @@ cards:
   hoverHint: ホバーしてモダンを見る →
   hoverHintRelated: ホバーしてモダンを見る ➜
   touchHint: 👆 タップまたはスワイプ →
+  learnMore: 詳しく見る
 copy:
   copy: コピー
   copied: コピーしました！

--- a/translations/strings/ko.yaml
+++ b/translations/strings/ko.yaml
@@ -47,6 +47,7 @@ cards:
   hoverHint: 마우스를 올려 모던 코드 보기 →
   hoverHintRelated: 마우스를 올려 모던 코드 보기 ➜
   touchHint: 👆 탭하거나 스와이프 →
+  learnMore: 자세히 보기
 copy:
   copy: 복사
   copied: 복사됨!

--- a/translations/strings/pt-BR.yaml
+++ b/translations/strings/pt-BR.yaml
@@ -48,6 +48,7 @@ cards:
   hoverHint: passe o mouse para ver o moderno →
   hoverHintRelated: Passe o mouse para ver o moderno ➜
   touchHint: 👆 toque ou deslize →
+  learnMore: saiba mais
 copy:
   copy: Copiar
   copied: Copiado!

--- a/translations/strings/zh-CN.yaml
+++ b/translations/strings/zh-CN.yaml
@@ -48,6 +48,7 @@ cards:
   hoverHint: 悬停查看现代版 →
   hoverHintRelated: 悬停查看现代版 ➜
   touchHint: 👆 点击或滑动 →
+  learnMore: 了解更多
 copy:
   copy: 复制
   copied: 已复制！


### PR DESCRIPTION
Replace the bare → arrow in card footers with a translated "learn more →" label, making the clickable action explicit for users.

## Changes
- **Template**: Updated `index-card.html` to use `{{cards.learnMore}} →`
- **Generator**: Added `cards.learnMore` token to the card rendering in `generate.java`
- **Translations**: Added `learnMore` key to all 9 locale string files

## Translations
| Locale | Text |
|--------|------|
| en | learn more → |
| de | mehr erfahren → |
| es | saber más → |
| fr | en savoir plus → |
| pt-BR | saiba mais → |
| zh-CN | 了解更多 → |
| ar | اعرف المزيد → |
| ja | 詳しく見る → |
| ko | 자세히 보기 → |